### PR TITLE
feat(deployment): add Deploy TUI orchestrator

### DIFF
--- a/projects/awsome-ai-gateway/deployment/scripts/deploy-tui.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/deploy-tui.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+# deploy-tui.sh — venv 부트스트랩 후 Deploy TUI 실행.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VENV="$REPO_ROOT/deployment/tui/.venv"
+
+if [ ! -d "$VENV" ]; then
+    echo "==> creating venv at $VENV"
+    python3 -m venv "$VENV"
+fi
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+pip install -q -r "$REPO_ROOT/deployment/tui/requirements.txt"
+
+cd "$REPO_ROOT"
+exec python -m deployment.tui

--- a/projects/awsome-ai-gateway/deployment/tui/README.md
+++ b/projects/awsome-ai-gateway/deployment/tui/README.md
@@ -1,0 +1,50 @@
+# Deploy CLI
+
+awsome-ai-gateway 배포 오케스트레이션 대화형 콘솔.
+
+Claude Code처럼 **인라인 콘솔**로 동작한다 — 전체 화면을 점유하지 않고 일반 셸
+스크롤버퍼에 append-only로 출력하므로 로그를 그대로 스크롤/복사할 수 있다.
+
+- 메뉴·선택: **화살표(↑↓)로 이동, Enter로 선택** (`questionary`)
+- 검색엔진 10종: **스페이스로 체크박스 토글** — 한 화면에서 다중선택
+- 출력(배너·사전검증 표·스텝 스트리밍): `rich`
+
+의존성은 `rich` + `questionary` 둘뿐. 풀스크린 점유 없이 인라인 유지.
+(화살표는 실제 터미널에서만 동작 — 파이프 입력 시 취소 처리)
+
+## 실행
+
+    ./deployment/scripts/deploy-tui.sh
+
+또는 repo 루트에서 직접:
+
+    deployment/tui/.venv/bin/python -m deployment.tui
+
+메뉴에서 워크플로우를 고르면 프롬프트로 값을 입력받고, 사전검증 표를 보여준 뒤
+확인을 받아 스텝을 하나씩 스트리밍 실행한다. `q`로 종료.
+
+대부분의 입력은 **default가 채워져 있어 Enter만 치면 넘어간다**:
+
+- aws_region (LLM GW): 기본 `ap-northeast-2`. tfvars의 `aws_region`과 `tf-init` backend region에 함께 주입되고, `azs`는 이 region 기반으로 자동 유도(`<region>a`/`<region>c`, 2 AZ). Tool GW는 us-east-1 고정(terraform validation)이라 입력받지 않는다.
+- tfstate bucket/table: `bootstrap-tfstate.sh` 네이밍 규칙 (`llm-gateway-tfstate` / `-tflock`)
+- Tool GW bucket: `tool-gateway-tfstate-<account-id>` (account id는 `aws sts`로 자동 조회)
+- cognito_domain_suffix 등: 기존 `terraform.tfvars`가 있으면 그 값으로 프리필
+
+## 무엇을 하나
+
+기존 배포 스크립트(`bootstrap-tfstate.sh`, `install-eks.sh`, `provision_tool_gateway.sh`, `smoke-test.sh`)와 `terraform`/`build-lambdas.sh`를 올바른 순서·env·인자로 호출한다. 배포 로직을 재구현하지 않는다.
+
+## 워크플로우
+
+- **LLM Gateway 배포** (region 선택, 기본 ap-northeast-2): 사전검증 → build-lambdas(조건부) → tf-init(backend 주입) → plan → apply → install-eks(KUBECONFIG 격리) → 검증
+- **Tool Gateway 배포** (us-east-1, 옵션): 사전검증 → 검색엔진 토글 + 키 → tfvars → tf-init → provision deploy
+- **전체 배포 (LLM → Tool)**: 위 둘을 순차 실행. Tool GW의 dashboard-env 연동은 LLM GW의 admin-ui가 떠 있어야 하므로 순서는 LLM→Tool 고정이며, LLM 단계가 실패/취소되면 Tool 단계는 게이팅되어 실행하지 않는다. Tool은 non-fatal 애드온이라 실패해도 LLM 배포에는 영향 없음.
+- **스택 삭제 (Teardown)**: 배포된 스택 삭제 (파괴적). LLM GW는 **helm uninstall(ALB 먼저 제거) → terraform destroy** 순서로 orphaned ENI 없이 VPC까지 삭제. Tool GW는 `provision_tool_gateway.sh teardown` 후 **AgentCore api-key credential provider orphan 정리**(terraform destroy가 못 지우는 경우 대비 — 이 스택이 만드는 bare 엔진명만 정확 일치로 삭제, `-creds` 등 타 스택 리소스는 보존). 실행 전 삭제 대상 요약을 보여주고, `delete <stack>` 문구를 **정확히 타이핑**해야 진행된다(이중 확인).
+
+## 함정 흡수
+
+`docs/superpowers/specs/2026-07-11-deploy-tui-design.md`의 "알려진 함정" 표 참조. TUI는 순서+env/인자 주입+검증 스텝으로 함정을 흡수한다.
+
+## 테스트
+
+    python -m pytest deployment/tui/tests/ -v

--- a/projects/awsome-ai-gateway/deployment/tui/README.md
+++ b/projects/awsome-ai-gateway/deployment/tui/README.md
@@ -26,7 +26,7 @@ Claude Code처럼 **인라인 콘솔**로 동작한다 — 전체 화면을 점�
 대부분의 입력은 **default가 채워져 있어 Enter만 치면 넘어간다**:
 
 - aws_region (LLM GW): 기본 `ap-northeast-2`. tfvars의 `aws_region`과 `tf-init` backend region에 함께 주입되고, `azs`는 이 region 기반으로 자동 유도(`<region>a`/`<region>c`, 2 AZ). Tool GW는 us-east-1 고정(terraform validation)이라 입력받지 않는다.
-- tfstate bucket/table: `bootstrap-tfstate.sh` 네이밍 규칙 (`llm-gateway-tfstate` / `-tflock`)
+- tfstate bucket/table (LLM GW): 계정 접미 규칙 `llm-gateway-vanilla-tfstate-<account-id>` / `llm-gateway-vanilla-tflock` (account id는 `aws sts`로 자동 조회, backend.tf 주석과 일치). 버킷은 S3 전역 유일성 때문에 계정 접미가 필수다.
 - Tool GW bucket: `tool-gateway-tfstate-<account-id>` (account id는 `aws sts`로 자동 조회)
 - cognito_domain_suffix 등: 기존 `terraform.tfvars`가 있으면 그 값으로 프리필
 

--- a/projects/awsome-ai-gateway/deployment/tui/__init__.py
+++ b/projects/awsome-ai-gateway/deployment/tui/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.

--- a/projects/awsome-ai-gateway/deployment/tui/__main__.py
+++ b/projects/awsome-ai-gateway/deployment/tui/__main__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/projects/awsome-ai-gateway/deployment/tui/cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/cli.py
@@ -204,14 +204,20 @@ def flow_llm() -> bool:
 
     # 기존 terraform.tfvars가 있으면 값 프리필 → Enter로 바로 넘어감
     tf_path = paths.llm_tf_dir(env) / "terraform.tfvars"
-    existing = config.parse_tfvars(tf_path.read_text()) if tf_path.exists() else {}
+    existing_text = tf_path.read_text() if tf_path.exists() else ""
+    existing = config.parse_tfvars(existing_text) if existing_text else {}
 
     # ★region: tfvars(aws_region)와 tfstate backend init 양쪽에 주입.
     #   azs는 region 기반으로 자동 유도(a/c 2 AZ — dev 비용 규칙)하되,
     #   기존 tfvars에 azs가 있으면 존중한다(멀티라인 list라 parse_tfvars엔 안 잡힘).
     region = ask_text("aws_region", default=existing.get("aws_region", "ap-northeast-2"))
     cognito = ask_text("cognito_domain_suffix", default=existing.get("cognito_domain_suffix", ""))
-    principal = ask_text("eks_access_entries principal_arn")
+    # principal_arn은 eks_access_entries 블록 안에 있어 parse_tfvars엔 안 잡힘 →
+    # 원문에서 직접 프리필해 재입력 없이 Enter로 넘어가게 한다.
+    principal = ask_text(
+        "eks_access_entries principal_arn",
+        default=config.prefill_scalar(existing_text, "principal_arn"),
+    )
 
     placeholders = config.find_placeholders(
         {"cognito_domain_suffix": cognito, "principal_arn": principal}
@@ -250,6 +256,22 @@ def flow_llm() -> bool:
     existing["azs"] = [f"{region}a", f"{region}c"]
     existing["enable_chat_agent"] = enable_chat_agent
     existing["enable_chat_db_tools"] = enable_chat_db
+    # ★eks_access_entries는 중첩 블록으로 기록해야 한다. 이전엔 principal_arn/policy_arn/
+    #   type이 최상위 scalar로 새어나가 'undeclared variable' 경고 + access entry 소실
+    #   ('cluster unreachable')을 유발했다. dict로 넣어 write_tfvars가 블록으로 직렬화.
+    existing["eks_access_entries"] = {
+        "developer": {
+            "principal_arn": principal,
+            "policy_associations": {
+                "admin": {
+                    "policy_arn": "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy",
+                    "access_scope": {"type": "cluster"},
+                }
+            },
+        }
+    }
+    # tags도 최상위가 아니라 map으로 기록(변수 선언이 map(string)).
+    existing["tags"] = {"CostCenter": "platform-ai", "Owner": "llm-gateway-team"}
     config.write_tfvars(tf_path, existing)
     console.print(f"[dim]tfvars 기록: {tf_path}[/dim]")
 
@@ -283,16 +305,23 @@ def flow_tool() -> bool:
         "검색엔진 활성화 (스페이스로 토글, Enter 확정)",
         [(eid, eid, False) for eid, _t, _k in ENGINES],
     )
+    # ★함정: API 키는 tfvars에 넣지 않는다. 넣으면 (1) terraform "undeclared variable"
+    #   경고 (2) 키가 tfstate(S3)에 평문 저장. 키는 별도 key file로 모아 TOOL_KEY_FILE로
+    #   provision 스크립트에 넘기고, seed-tool-secrets.sh가 Secrets Manager에 직접 주입한다.
+    keys: dict[str, str] = {}
     for eid, toggle, needs_key in ENGINES:
         enabled = eid in enabled_ids
         tfvars[toggle] = enabled
         if needs_key and enabled:
-            key = ask_password(f"{eid} API key")
-            tfvars[f"{eid}_api_key"] = key
+            keys[eid] = ask_password(f"{eid} API key")
 
     tf_path = paths.TOOL_TF_DIR / "terraform.tfvars"
     config.write_tfvars(tf_path, tfvars)
     console.print(f"[dim]tfvars 기록: {tf_path}[/dim]")
+
+    key_file = config.write_key_file(keys)
+    if key_file:
+        console.print(f"[dim]API 키 {len(keys)}개 → Secrets Manager 주입 예정 (tfstate 미경유)[/dim]")
 
     # tool-gateway tfstate bucket은 account-id 포함이 규칙 → 자동 조회해 default 구성
     acct = aws_account_id()
@@ -301,14 +330,27 @@ def flow_tool() -> bool:
     table = ask_text("tfstate dynamodb table", default="tool-gateway-tflock")
     # Tool GW는 us-east-1 고정(terraform validation) → backend region도 고정.
     backend = BackendConfig(bucket=bucket, dynamodb_table=table, region="us-east-1")
-    wf = build_tool_workflow(backend=backend, has_key_file=False)
+    wf = build_tool_workflow(backend=backend, key_file=key_file)
 
     _preview_steps(wf)
     console.print("[dim]Tool Gateway는 non-fatal 애드온 — 실패해도 LLM GW에 영향 없음[/dim]")
     if not ask_confirm("위 스텝을 실행합니다 (실제 배포) — 계속?", default=False):
         console.print("[dim]취소됨[/dim]")
+        _cleanup_key_file(key_file)
         return False
-    return run_and_report(wf, "Tool Gateway")
+    try:
+        return run_and_report(wf, "Tool Gateway")
+    finally:
+        # 키 파일은 seed 후 즉시 제거 — 평문 키가 디스크에 남지 않도록.
+        _cleanup_key_file(key_file)
+
+
+def _cleanup_key_file(key_file) -> None:
+    if key_file:
+        try:
+            key_file.unlink()
+        except OSError:
+            pass
 
 
 # --------------------------------------------------------------------------- #

--- a/projects/awsome-ai-gateway/deployment/tui/cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/cli.py
@@ -1,0 +1,416 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""인라인 콘솔 UI — Claude Code처럼 터미널에 흘려쓰는 가벼운 배포 오케스트레이터.
+
+Textual 풀스크린 대신 rich로 append-only 출력을 낸다. 전체 화면을 점유하지
+않고 일반 셸 스크롤버퍼에 남으므로, 로그를 그대로 복사/스크롤할 수 있다.
+
+UI 조립만 담당하고 배포 로직은 config/steps/preflight/runner를 그대로 재사용한다."""
+from __future__ import annotations
+
+import questionary
+from questionary import Choice
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from . import config, paths, preflight
+from .config import BackendConfig
+from .steps import (
+    build_llm_teardown,
+    build_llm_workflow,
+    build_tool_teardown,
+    build_tool_workflow,
+)
+
+console = Console()
+
+
+# --------------------------------------------------------------------------- #
+# 입력 래퍼 — questionary 화살표/체크박스. 여기만 인터랙션을 캡슐화한다.
+# .ask()는 Ctrl-C 시 None을 반환하므로 취소로 처리한다.
+# --------------------------------------------------------------------------- #
+class Cancelled(Exception):
+    """사용자가 프롬프트를 Ctrl-C/Esc로 취소."""
+
+
+def _unwrap(value):
+    if value is None:
+        raise Cancelled
+    return value
+
+
+def ask_select(message: str, choices) -> str:
+    """화살표 단일선택. choices: [(label, value), ...] 또는 [str, ...]."""
+    opts = [c if isinstance(c, str) else Choice(title=c[0], value=c[1]) for c in choices]
+    return _unwrap(questionary.select(message, choices=opts).ask())
+
+
+def ask_checkbox(message: str, choices) -> list:
+    """스페이스 토글 다중선택. choices: [(label, value, checked), ...]."""
+    opts = [Choice(title=c[0], value=c[1], checked=c[2]) for c in choices]
+    return _unwrap(questionary.checkbox(message, choices=opts).ask())
+
+
+def ask_text(message: str, default: str = "") -> str:
+    return _unwrap(questionary.text(message, default=default).ask())
+
+
+def ask_password(message: str) -> str:
+    return _unwrap(questionary.password(message).ask())
+
+
+def ask_confirm(message: str, default: bool = False) -> bool:
+    return _unwrap(questionary.confirm(message, default=default).ask())
+
+# 검색엔진: (id, tfvars_toggle, needs_key)
+ENGINES = [
+    ("duckduckgo", "enable_duckduckgo", False),
+    ("tavily", "enable_tavily", True),
+    ("brave", "enable_brave", True),
+    ("serper", "enable_serper", True),
+    ("exa", "enable_exa", True),
+    ("perplexity", "enable_perplexity", True),
+    ("anthropic", "enable_anthropic", True),
+    ("firecrawl", "enable_firecrawl", True),
+    ("you", "enable_you", True),
+]
+
+
+# --------------------------------------------------------------------------- #
+# 표시 헬퍼
+# --------------------------------------------------------------------------- #
+def banner() -> None:
+    console.print(
+        Panel(
+            Text("awsome-ai-gateway 배포 오케스트레이터", justify="center", style="bold cyan"),
+            border_style="cyan",
+        )
+    )
+
+
+def preflight_table(checks) -> bool:
+    """CheckResult 리스트를 표로 출력하고 전부 통과했는지 반환."""
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("check")
+    table.add_column("status")
+    table.add_column("detail", style="dim")
+    all_ok = True
+    for c in checks:
+        mark = "[green]✓[/green]" if c.ok else "[red]✗[/red]"
+        table.add_row(c.name, mark, c.detail)
+        all_ok = all_ok and c.ok
+    console.print(table)
+    return all_ok
+
+
+def run_preflight(tools) -> bool:
+    checks = preflight.check_tools(tools)
+    checks.append(preflight.check_aws_auth())
+    return preflight_table(checks)
+
+
+def aws_account_id() -> str | None:
+    """현재 자격증명의 AWS account ID (best-effort). 실패 시 None."""
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError:
+        return None
+    acct = proc.stdout.strip()
+    return acct if proc.returncode == 0 and acct else None
+
+
+# --------------------------------------------------------------------------- #
+# 워크플로우 실행 — 스텝 단위 append-only 스트리밍
+# --------------------------------------------------------------------------- #
+def run_and_report(wf, title: str) -> bool:
+    """runner.run_workflow를 인라인 스트리밍으로 구동. 전체 성공 여부 반환."""
+    # 실행 지점에서 지연 import — runner는 subprocess를 돌리므로 테스트에서 격리
+    from .runner import run_workflow
+
+    console.rule(f"[bold]{title}[/bold]")
+
+    def on_step_start(step) -> None:
+        skip = " [dim](skippable)[/dim]" if step.skippable else ""
+        console.print(f"[cyan]▶[/cyan] {step.name}{skip}")
+
+    def on_line(line: str) -> None:
+        console.print(f"  [dim]│[/dim] {line}", highlight=False)
+
+    def on_step_done(result) -> None:
+        if result.ok:
+            console.print(f"[green]✓[/green] {result.step.name}")
+        else:
+            console.print(f"[red]✗[/red] {result.step.name} (exit {result.returncode})")
+
+    results = run_workflow(
+        wf, on_line=on_line, on_step_done=on_step_done, on_step_start=on_step_start
+    )
+    ok = bool(results) and all(r.ok for r in results)
+    if ok:
+        console.print(f"\n[bold green]완료[/bold green] — {title}")
+    else:
+        failed = next((r for r in results if not r.ok), None)
+        where = f" ({failed.step.name})" if failed else ""
+        console.print(f"\n[bold red]실패[/bold red]{where} — 위 로그를 확인하세요")
+    return ok
+
+
+# --------------------------------------------------------------------------- #
+# 워크플로우 A — LLM Gateway
+# --------------------------------------------------------------------------- #
+def flow_llm() -> bool:
+    """LLM Gateway 배포. 실제 배포 후 성공하면 True, 미배포/취소/실패면 False."""
+    console.rule("[bold]LLM Gateway 배포[/bold]")
+    if not run_preflight(preflight.LLM_TOOLS):
+        console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결한 뒤 다시 실행하세요.")
+        return False
+
+    env = ask_select("환경", ["dev", "prod"])
+
+    # 기존 terraform.tfvars가 있으면 값 프리필 → Enter로 바로 넘어감
+    tf_path = paths.llm_tf_dir(env) / "terraform.tfvars"
+    existing = config.parse_tfvars(tf_path.read_text()) if tf_path.exists() else {}
+
+    # ★region: tfvars(aws_region)와 tfstate backend init 양쪽에 주입.
+    #   azs는 region 기반으로 자동 유도(a/c 2 AZ — dev 비용 규칙)하되,
+    #   기존 tfvars에 azs가 있으면 존중한다(멀티라인 list라 parse_tfvars엔 안 잡힘).
+    region = ask_text("aws_region", default=existing.get("aws_region", "ap-northeast-2"))
+    cognito = ask_text("cognito_domain_suffix", default=existing.get("cognito_domain_suffix", ""))
+    principal = ask_text("eks_access_entries principal_arn")
+
+    placeholders = config.find_placeholders(
+        {"cognito_domain_suffix": cognito, "principal_arn": principal}
+    )
+    if placeholders:
+        console.print(f"[red]플레이스홀더 남음:[/red] {', '.join(placeholders)}")
+        return False
+
+    # bootstrap-tfstate.sh 기본 네이밍 규칙 → default로 제공 (Enter로 수락)
+    bucket = ask_text("tfstate bucket", default="llm-gateway-tfstate")
+    table = ask_text("tfstate dynamodb table", default="llm-gateway-tflock")
+    enable_chat_agent = ask_confirm("enable_chat_agent?", default=True)
+    enable_chat_db = ask_confirm("enable_chat_db_tools? (Lambda 빌드 선행)", default=True)
+    # 실행 플래그는 체크박스 한 화면에서 토글
+    selected_flags = ask_checkbox(
+        "install-eks 실행 플래그 (스페이스로 토글)",
+        [
+            ("DEBUG_MODE", "DEBUG_MODE", False),
+            ("MIGRATION_ENABLED", "MIGRATION_ENABLED", True),
+            ("FORCE_CONFLICTS", "FORCE_CONFLICTS", False),
+        ],
+    )
+    flags = {
+        f: (f in selected_flags)
+        for f in ("DEBUG_MODE", "MIGRATION_ENABLED", "FORCE_CONFLICTS")
+    }
+
+    # tfvars 병합 기록 (위에서 읽은 existing에 폼 값 반영)
+    if cognito:
+        existing["cognito_domain_suffix"] = cognito
+    # region + region 기반 azs 자동 유도(2 AZ: a/c). write_tfvars가 dict 전체를
+    # 재직렬화하므로 멀티라인 list인 azs가 파일에서 빠지지 않도록 명시 기록한다.
+    existing["aws_region"] = region
+    existing["azs"] = [f"{region}a", f"{region}c"]
+    existing["enable_chat_agent"] = enable_chat_agent
+    existing["enable_chat_db_tools"] = enable_chat_db
+    config.write_tfvars(tf_path, existing)
+    console.print(f"[dim]tfvars 기록: {tf_path}[/dim]")
+
+    backend = BackendConfig(bucket=bucket, dynamodb_table=table, region=region)
+    wf = build_llm_workflow(
+        env=env, backend=backend, enable_chat_db_tools=enable_chat_db, flags=flags
+    )
+
+    _preview_steps(wf)
+    if not ask_confirm("위 스텝을 실행합니다 (실제 배포) — 계속?", default=False):
+        console.print("[dim]취소됨[/dim]")
+        return False
+    return run_and_report(wf, f"LLM Gateway {env}")
+
+
+# --------------------------------------------------------------------------- #
+# 워크플로우 B — Tool Gateway
+# --------------------------------------------------------------------------- #
+def flow_tool() -> bool:
+    """Tool Gateway 배포. 성공 True, 미배포/취소/실패 False (non-fatal 애드온)."""
+    console.rule("[bold]Tool Gateway 배포[/bold]")
+    if not run_preflight(preflight.TOOL_GW_TOOLS):
+        console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결한 뒤 다시 실행하세요.")
+        return False
+
+    tfvars = {"project_name": "toolgw-demo", "environment": "dev", "aws_region": "us-east-1"}
+    # 검색엔진 10종을 한 화면에서 스페이스로 토글
+    enabled_ids = ask_checkbox(
+        "검색엔진 활성화 (스페이스로 토글, Enter 확정)",
+        [(eid, eid, False) for eid, _t, _k in ENGINES],
+    )
+    for eid, toggle, needs_key in ENGINES:
+        enabled = eid in enabled_ids
+        tfvars[toggle] = enabled
+        if needs_key and enabled:
+            key = ask_password(f"{eid} API key")
+            tfvars[f"{eid}_api_key"] = key
+
+    tf_path = paths.TOOL_TF_DIR / "terraform.tfvars"
+    config.write_tfvars(tf_path, tfvars)
+    console.print(f"[dim]tfvars 기록: {tf_path}[/dim]")
+
+    # tool-gateway tfstate bucket은 account-id 포함이 규칙 → 자동 조회해 default 구성
+    acct = aws_account_id()
+    bucket_default = f"tool-gateway-tfstate-{acct}" if acct else "tool-gateway-tfstate"
+    bucket = ask_text("tfstate bucket", default=bucket_default)
+    table = ask_text("tfstate dynamodb table", default="tool-gateway-tflock")
+    # Tool GW는 us-east-1 고정(terraform validation) → backend region도 고정.
+    backend = BackendConfig(bucket=bucket, dynamodb_table=table, region="us-east-1")
+    wf = build_tool_workflow(backend=backend, has_key_file=False)
+
+    _preview_steps(wf)
+    console.print("[dim]Tool Gateway는 non-fatal 애드온 — 실패해도 LLM GW에 영향 없음[/dim]")
+    if not ask_confirm("위 스텝을 실행합니다 (실제 배포) — 계속?", default=False):
+        console.print("[dim]취소됨[/dim]")
+        return False
+    return run_and_report(wf, "Tool Gateway")
+
+
+# --------------------------------------------------------------------------- #
+# 워크플로우 A+B — 전체 배포 (LLM → Tool 순서)
+# --------------------------------------------------------------------------- #
+def flow_all() -> bool:
+    """LLM Gateway → Tool Gateway 순차 배포.
+
+    Tool GW(B)의 dashboard-env 연동은 LLM GW(A)의 admin-ui가 떠 있어야 하므로
+    순서는 A→B 고정. A가 실패/취소되면 B는 진행하지 않는다(의존성 게이팅)."""
+    console.rule("[bold]전체 배포 (LLM → Tool)[/bold]")
+    console.print("[dim]LLM Gateway를 먼저 배포한 뒤 Tool Gateway를 이어서 배포합니다.[/dim]")
+
+    llm_ok = flow_llm()
+    if not llm_ok:
+        console.print(
+            "\n[bold red]LLM Gateway 미완료[/bold red] — Tool Gateway는 admin-ui 의존성 때문에 "
+            "진행하지 않습니다. LLM Gateway를 먼저 완료하세요."
+        )
+        return False
+
+    console.print("\n[bold]LLM Gateway 완료 → Tool Gateway로 이어갑니다[/bold]")
+    tool_ok = flow_tool()
+
+    if tool_ok:
+        console.print("\n[bold green]전체 배포 완료[/bold green] — LLM + Tool Gateway")
+    else:
+        console.print(
+            "\n[yellow]LLM Gateway는 배포됨. Tool Gateway는 미완료(취소/실패) — "
+            "non-fatal 애드온이라 LLM GW에는 영향 없습니다.[/yellow]"
+        )
+    return llm_ok and tool_ok
+
+
+def _preview_steps(wf) -> None:
+    console.print("\n[bold]실행 스텝:[/bold]")
+    for i, step in enumerate(wf, 1):
+        skip = " [dim](skippable)[/dim]" if step.skippable else ""
+        console.print(f"  {i}. {step.name}{skip}")
+    console.print()
+
+
+# --------------------------------------------------------------------------- #
+# 워크플로우 C — 스택 삭제 (Teardown)
+# --------------------------------------------------------------------------- #
+def flow_teardown() -> bool:
+    """배포된 스택 삭제. 파괴적 작업이라 대상 요약 + 이중 확인(타이핑) 필수."""
+    console.rule("[bold red]스택 삭제 (Teardown)[/bold red]")
+    target = ask_select(
+        "무엇을 삭제할까요?",
+        [
+            ("LLM Gateway (ap-northeast-2)", "llm"),
+            ("Tool Gateway (us-east-1)", "tool"),
+            ("취소", "__cancel__"),
+        ],
+    )
+    if target == "__cancel__":
+        console.print("[dim]취소됨[/dim]")
+        return False
+
+    if target == "llm":
+        if not run_preflight(preflight.LLM_TOOLS):
+            console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결하세요.")
+            return False
+        env = ask_select("환경", ["dev", "prod"])
+        # destroy도 backend init이 필요 → 배포 시 쓴 region과 일치해야 state를 찾는다.
+        region = ask_text("aws_region", default="ap-northeast-2")
+        bucket = ask_text("tfstate bucket", default="llm-gateway-tfstate")
+        tftable = ask_text("tfstate dynamodb table", default="llm-gateway-tflock")
+        backend = BackendConfig(bucket=bucket, dynamodb_table=tftable, region=region)
+        wf = build_llm_teardown(env=env, backend=backend)
+        summary = (
+            f"llm-gateway-{env} 의 [bold]모든 terraform 리소스[/bold]"
+            " (EKS 클러스터, VPC, Aurora, ElastiCache, Cognito, ECR 등)"
+        )
+        confirm_token = f"delete llm-gateway-{env}"
+        title = f"Teardown LLM Gateway {env}"
+    else:  # tool
+        if not run_preflight(preflight.TOOL_GW_TOOLS):
+            console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결하세요.")
+            return False
+        wf = build_tool_teardown()
+        summary = "tool-gateway-dev 의 [bold]모든 terraform 리소스[/bold] (Gateway, Lambda tools, secrets 등)"
+        confirm_token = "delete tool-gateway"
+        title = "Teardown Tool Gateway"
+
+    _preview_steps(wf)
+    console.print(
+        f"[bold red]⚠ 파괴적 작업[/bold red] — 삭제 대상: {summary}\n"
+        "[red]이 작업은 되돌릴 수 없습니다.[/red]"
+    )
+    # 이중 확인: 정확한 문구를 타이핑해야 진행
+    typed = ask_text(f'확인을 위해 [bold]{confirm_token}[/bold] 를 그대로 입력하세요')
+    if typed.strip() != confirm_token:
+        console.print("[dim]문구 불일치 — 삭제를 취소합니다[/dim]")
+        return False
+    return run_and_report(wf, title)
+
+
+# --------------------------------------------------------------------------- #
+# 메인 루프
+# --------------------------------------------------------------------------- #
+# (label, handler)
+MENU = [
+    ("LLM Gateway 배포", flow_llm),
+    ("Tool Gateway 배포", flow_tool),
+    ("전체 배포 (LLM → Tool)", flow_all),
+    ("스택 삭제 (Teardown)", flow_teardown),
+]
+
+
+def main_menu() -> None:
+    banner()
+    while True:
+        console.print()
+        # 화살표 단일선택 — 각 워크플로우 핸들러를 value로.
+        # questionary.Choice는 value=None을 title로 대체하므로 종료는 센티널 문자열 사용.
+        choices = [(label, handler) for label, handler in MENU]
+        choices.append(("종료", "__exit__"))
+        handler = ask_select("워크플로우 선택 (↑↓ 이동, Enter 선택)", choices)
+        if handler == "__exit__":
+            console.print("[dim]bye[/dim]")
+            return
+        try:
+            handler()
+        except Cancelled:
+            console.print("\n[dim]취소됨 — 메뉴로 돌아갑니다[/dim]")
+
+
+def main() -> None:
+    try:
+        main_menu()
+    except (Cancelled, KeyboardInterrupt, EOFError):
+        console.print("\n[dim]bye[/dim]")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/awsome-ai-gateway/deployment/tui/cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/cli.py
@@ -110,6 +110,20 @@ def run_preflight(tools) -> bool:
     return preflight_table(checks)
 
 
+def tool_gateway_assets_ok() -> bool:
+    """Tool Gateway 스크립트/terraform이 이 리포에 있는지 확인하고 표로 출력.
+    없으면(별도 PR 미머지 등) 안내하고 False."""
+    checks = preflight.check_tool_gateway_assets()
+    ok = preflight_table(checks)
+    if not ok:
+        console.print(
+            "[yellow]Tool Gateway 자산(provision 스크립트/terraform)이 이 리포에 없습니다.[/yellow]\n"
+            "[dim]Tool Gateway 통합 PR이 머지된 브랜치에서 실행하세요. "
+            "LLM Gateway 워크플로우는 영향받지 않습니다.[/dim]"
+        )
+    return ok
+
+
 def aws_account_id() -> str | None:
     """현재 자격증명의 AWS account ID (best-effort). 실패 시 None."""
     import subprocess
@@ -123,6 +137,16 @@ def aws_account_id() -> str | None:
         return None
     acct = proc.stdout.strip()
     return acct if proc.returncode == 0 and acct else None
+
+
+def llm_tfstate_defaults(acct: str | None) -> tuple[str, str]:
+    """LLM Gateway tfstate 버킷/락테이블 default.
+
+    실제 배포·backend.tf 주석의 규칙은 `llm-gateway-vanilla-tfstate-<account>`
+    (버킷은 S3 전역 유일성 때문에 계정 접미 필수) + `llm-gateway-vanilla-tflock`.
+    account id를 못 구하면 접미 없는 형태로 fallback(사용자가 직접 수정)."""
+    suffix = f"-{acct}" if acct else ""
+    return f"llm-gateway-vanilla-tfstate{suffix}", "llm-gateway-vanilla-tflock"
 
 
 # --------------------------------------------------------------------------- #
@@ -145,17 +169,22 @@ def run_and_report(wf, title: str) -> bool:
     def on_step_done(result) -> None:
         if result.ok:
             console.print(f"[green]✓[/green] {result.step.name}")
+        elif result.step.skippable:
+            # best-effort 스텝 실패는 경고로만 — 워크플로우는 계속 진행된다
+            console.print(f"[yellow]⚠[/yellow] {result.step.name} (exit {result.returncode}, skippable — 계속 진행)")
         else:
             console.print(f"[red]✗[/red] {result.step.name} (exit {result.returncode})")
 
     results = run_workflow(
         wf, on_line=on_line, on_step_done=on_step_done, on_step_start=on_step_start
     )
-    ok = bool(results) and all(r.ok for r in results)
+    # skippable 스텝 실패는 전체 성공 판정에서 제외(best-effort). 필수 스텝만 성공하면 완료.
+    ok = bool(results) and all(r.ok or r.step.skippable for r in results)
     if ok:
         console.print(f"\n[bold green]완료[/bold green] — {title}")
     else:
-        failed = next((r for r in results if not r.ok), None)
+        # 정지 사유는 필수(non-skippable) 스텝 실패 — 그걸 가리킨다
+        failed = next((r for r in results if not r.ok and not r.step.skippable), None)
         where = f" ({failed.step.name})" if failed else ""
         console.print(f"\n[bold red]실패[/bold red]{where} — 위 로그를 확인하세요")
     return ok
@@ -191,9 +220,11 @@ def flow_llm() -> bool:
         console.print(f"[red]플레이스홀더 남음:[/red] {', '.join(placeholders)}")
         return False
 
-    # bootstrap-tfstate.sh 기본 네이밍 규칙 → default로 제공 (Enter로 수락)
-    bucket = ask_text("tfstate bucket", default="llm-gateway-tfstate")
-    table = ask_text("tfstate dynamodb table", default="llm-gateway-tflock")
+    # tfstate 버킷은 계정 접미 규칙(llm-gateway-vanilla-tfstate-<account>) →
+    # account id를 조회해 default 구성(Enter로 수락). backend.tf 주석과 일치.
+    b_default, t_default = llm_tfstate_defaults(aws_account_id())
+    bucket = ask_text("tfstate bucket", default=b_default)
+    table = ask_text("tfstate dynamodb table", default=t_default)
     enable_chat_agent = ask_confirm("enable_chat_agent?", default=True)
     enable_chat_db = ask_confirm("enable_chat_db_tools? (Lambda 빌드 선행)", default=True)
     # 실행 플래그는 체크박스 한 화면에서 토글
@@ -242,6 +273,8 @@ def flow_tool() -> bool:
     console.rule("[bold]Tool Gateway 배포[/bold]")
     if not run_preflight(preflight.TOOL_GW_TOOLS):
         console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결한 뒤 다시 실행하세요.")
+        return False
+    if not tool_gateway_assets_ok():
         return False
 
     tfvars = {"project_name": "toolgw-demo", "environment": "dev", "aws_region": "us-east-1"}
@@ -343,8 +376,10 @@ def flow_teardown() -> bool:
         env = ask_select("환경", ["dev", "prod"])
         # destroy도 backend init이 필요 → 배포 시 쓴 region과 일치해야 state를 찾는다.
         region = ask_text("aws_region", default="ap-northeast-2")
-        bucket = ask_text("tfstate bucket", default="llm-gateway-tfstate")
-        tftable = ask_text("tfstate dynamodb table", default="llm-gateway-tflock")
+        # 배포와 동일한 계정 접미 규칙으로 default 구성(불일치 시 AccessDenied/301).
+        b_default, t_default = llm_tfstate_defaults(aws_account_id())
+        bucket = ask_text("tfstate bucket", default=b_default)
+        tftable = ask_text("tfstate dynamodb table", default=t_default)
         backend = BackendConfig(bucket=bucket, dynamodb_table=tftable, region=region)
         wf = build_llm_teardown(env=env, backend=backend)
         summary = (
@@ -356,6 +391,8 @@ def flow_teardown() -> bool:
     else:  # tool
         if not run_preflight(preflight.TOOL_GW_TOOLS):
             console.print("[red]사전검증 실패[/red] — 누락 도구/인증을 해결하세요.")
+            return False
+        if not tool_gateway_assets_ok():
             return False
         wf = build_tool_teardown()
         summary = "tool-gateway-dev 의 [bold]모든 terraform 리소스[/bold] (Gateway, Lambda tools, secrets 등)"

--- a/projects/awsome-ai-gateway/deployment/tui/config.py
+++ b/projects/awsome-ai-gateway/deployment/tui/config.py
@@ -2,6 +2,8 @@
 """폼 입력 ↔ terraform.tfvars 직렬화/파싱 + 플레이스홀더 검증. 순수 함수만."""
 from __future__ import annotations
 
+import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,18 +27,27 @@ def find_placeholders(values: dict[str, str]) -> list[str]:
     return flagged
 
 
-def _hcl_value(val) -> str:
+def _hcl_value(val, indent: int = 0) -> str:
     if isinstance(val, bool):
         return "true" if val else "false"
     if isinstance(val, (int, float)):
         return str(val)
     if isinstance(val, list):
-        return "[" + ", ".join(_hcl_value(v) for v in val) + "]"
+        return "[" + ", ".join(_hcl_value(v, indent) for v in val) + "]"
+    if isinstance(val, dict):
+        # HCL object/map: 중첩 블록(eks_access_entries, tags 등)을 들여쓰기해 직렬화.
+        # key는 bare identifier로 씀(tfvars object 문법).
+        pad = "  " * (indent + 1)
+        close = "  " * indent
+        inner = "\n".join(
+            f"{pad}{k} = {_hcl_value(v, indent + 1)}" for k, v in val.items()
+        )
+        return "{\n" + inner + "\n" + close + "}"
     return f'"{val}"'
 
 
 def to_tfvars(values: dict) -> str:
-    """dict를 HCL tfvars 문자열로 직렬화."""
+    """dict를 HCL tfvars 문자열로 직렬화. dict 값은 중첩 블록으로 나감."""
     return "\n".join(f"{k} = {_hcl_value(v)}" for k, v in values.items()) + "\n"
 
 
@@ -44,14 +55,53 @@ def write_tfvars(path: Path, values: dict) -> None:
     path.write_text(to_tfvars(values))
 
 
+def to_key_file(keys: dict[str, str]) -> str:
+    """{engine: api_key} → seed-tool-secrets.sh 형식(`engine=value` 줄) 직렬화.
+
+    API 키는 절대 terraform(tfvars/tfstate)을 거치면 안 되고, 이 파일 형식으로
+    provision_tool_gateway.sh 의 TOOL_KEY_FILE 에 넘겨 Secrets Manager 에 직접
+    주입한다. 빈 값 엔진은 건너뛴다."""
+    return "".join(f"{engine}={key}\n" for engine, key in keys.items() if key)
+
+
+def write_key_file(keys: dict[str, str]) -> Path:
+    """키를 0600 권한 임시 파일에 기록하고 경로를 반환. 값이 하나도 없으면 만들지 않는다.
+
+    tfvars 처럼 리포 안에 두지 않는다 — seed 후 호출측이 지운다."""
+    body = to_key_file(keys)
+    if not body:
+        return None
+    fd, name = tempfile.mkstemp(prefix="tool-keys-", suffix=".env")
+    try:
+        os.write(fd, body.encode())
+    finally:
+        os.close(fd)
+    os.chmod(name, 0o600)
+    return Path(name)
+
+
 def parse_tfvars(text: str) -> dict:
-    """기존 tfvars에서 `key = value`를 단순 파싱(프리필용). 문자열/bool/숫자만."""
+    """기존 tfvars에서 최상위 `key = value` scalar만 파싱(프리필용).
+
+    중첩 블록({...}) 내부 줄은 건너뛴다 — 안 그러면 eks_access_entries/tags 안의
+    principal_arn·CostCenter 등이 최상위 키로 잘못 승격돼, 재직렬화 시 블록 구조가
+    깨지고 'undeclared variable' 경고 + access entry 소실로 이어진다.
+    문자열/bool/숫자 scalar만 반환하고 list/dict(멀티라인) 값은 프리필 대상이 아니다.
+    """
     result: dict = {}
+    depth = 0
     for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
+        stripped = line.strip()
+        opens, closes = stripped.count("{"), stripped.count("}")
+        at_top = depth == 0
+        depth += opens - closes
+        if not at_top:
+            continue  # 중첩 블록 내부 — 승격 금지
+        if opens > closes:
+            continue  # 이 줄이 블록을 열었음 (예: `tags = {`)
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
             continue
-        key, _, raw = line.partition("=")
+        key, _, raw = stripped.partition("=")
         key, raw = key.strip(), raw.strip()
         if raw in ("true", "false"):
             result[key] = raw == "true"
@@ -61,6 +111,22 @@ def parse_tfvars(text: str) -> dict:
             result[key] = int(raw)
         # list/multiline 값은 프리필 대상 아님 — 무시
     return result
+
+
+def prefill_scalar(text: str, key: str) -> str:
+    """tfvars 원문에서 `key = "..."` scalar를 깊이 무관하게 첫 매치로 추출(프리필 default용).
+
+    parse_tfvars는 중첩 블록을 건너뛰므로, 블록 안에 있는 principal_arn 같은 값을
+    재입력 없이 프리필하려면 별도로 스캔해야 한다."""
+    for line in text.splitlines():
+        s = line.strip()
+        k, sep, raw = s.partition("=")
+        if not sep or k.strip() != key:
+            continue
+        raw = raw.strip()
+        if raw.startswith('"') and raw.endswith('"'):
+            return raw[1:-1]
+    return ""
 
 
 @dataclass

--- a/projects/awsome-ai-gateway/deployment/tui/config.py
+++ b/projects/awsome-ai-gateway/deployment/tui/config.py
@@ -1,0 +1,83 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""폼 입력 ↔ terraform.tfvars 직렬화/파싱 + 플레이스홀더 검증. 순수 함수만."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+PLACEHOLDER_TOKENS: tuple[str, ...] = (
+    "CHANGE_ME",
+    "CHANGE_ACCOUNT_ID",
+    "ACCOUNT_ID",
+    "YOUR_ROLE",
+    "tvly-...",
+    "BSA...",
+    "sk-...",
+)
+
+
+def find_placeholders(values: dict[str, str]) -> list[str]:
+    """값에 플레이스홀더 토큰이 남은 key 목록을 반환."""
+    flagged = []
+    for key, val in values.items():
+        if isinstance(val, str) and any(tok in val for tok in PLACEHOLDER_TOKENS):
+            flagged.append(key)
+    return flagged
+
+
+def _hcl_value(val) -> str:
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, (int, float)):
+        return str(val)
+    if isinstance(val, list):
+        return "[" + ", ".join(_hcl_value(v) for v in val) + "]"
+    return f'"{val}"'
+
+
+def to_tfvars(values: dict) -> str:
+    """dict를 HCL tfvars 문자열로 직렬화."""
+    return "\n".join(f"{k} = {_hcl_value(v)}" for k, v in values.items()) + "\n"
+
+
+def write_tfvars(path: Path, values: dict) -> None:
+    path.write_text(to_tfvars(values))
+
+
+def parse_tfvars(text: str) -> dict:
+    """기존 tfvars에서 `key = value`를 단순 파싱(프리필용). 문자열/bool/숫자만."""
+    result: dict = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, raw = line.partition("=")
+        key, raw = key.strip(), raw.strip()
+        if raw in ("true", "false"):
+            result[key] = raw == "true"
+        elif raw.startswith('"') and raw.endswith('"'):
+            result[key] = raw[1:-1]
+        elif raw.lstrip("-").isdigit():
+            result[key] = int(raw)
+        # list/multiline 값은 프리필 대상 아님 — 무시
+    return result
+
+
+@dataclass
+class BackendConfig:
+    """tfstate 백엔드 — bootstrap과 tf-init에 동일 값 주입하는 단일 소스.
+
+    region이 지정되면 tfstate 버킷 region도 -backend-config로 덮어쓴다. 빈 값이면
+    backend.tf에 하드코딩된 region을 그대로 쓴다(하위호환)."""
+    bucket: str
+    dynamodb_table: str
+    region: str = ""
+
+    def backend_args(self) -> list[str]:
+        args = [
+            f"-backend-config=bucket={self.bucket}",
+            f"-backend-config=dynamodb_table={self.dynamodb_table}",
+        ]
+        if self.region:
+            args.append(f"-backend-config=region={self.region}")
+        return args

--- a/projects/awsome-ai-gateway/deployment/tui/paths.py
+++ b/projects/awsome-ai-gateway/deployment/tui/paths.py
@@ -1,0 +1,21 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""리포 내 배포 아티팩트 경로 상수. 하드코딩 경로를 한 곳에 모은다."""
+from pathlib import Path
+
+# paths.py = .../deployment/tui/paths.py → parents[2] = repo root
+DEPLOY_DIR = Path(__file__).resolve().parents[1]          # .../deployment
+REPO_ROOT = DEPLOY_DIR.parent                             # repo root
+SCRIPTS_DIR = DEPLOY_DIR / "scripts"
+TF_ENV_DIR = DEPLOY_DIR / "terraform" / "environments"
+TOOL_TF_DIR = TF_ENV_DIR / "tool-gateway-dev"
+BUILD_LAMBDAS_SH = REPO_ROOT / "admin-chat-agent" / "lambdas" / "build-lambdas.sh"
+
+
+def llm_tf_dir(env: str) -> Path:
+    """LLM Gateway terraform 환경 디렉토리 (env: dev|prod)."""
+    return TF_ENV_DIR / f"llm-gateway-{env}"
+
+
+def script(name: str) -> Path:
+    """deployment/scripts/<name> 절대 경로."""
+    return SCRIPTS_DIR / name

--- a/projects/awsome-ai-gateway/deployment/tui/preflight.py
+++ b/projects/awsome-ai-gateway/deployment/tui/preflight.py
@@ -1,0 +1,37 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""배포 전 사전검증 — 도구 설치 여부, AWS 인증."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+LLM_TOOLS = ["aws", "kubectl", "helm", "terraform", "jq", "python3"]
+TOOL_GW_TOOLS = ["terraform", "aws", "jq", "python3"]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+def check_tools(tools, which=shutil.which) -> list[CheckResult]:
+    results = []
+    for t in tools:
+        path = which(t)
+        results.append(CheckResult(name=t, ok=path is not None, detail=path or "not found in PATH"))
+    return results
+
+
+def check_aws_auth(runner=subprocess.run) -> CheckResult:
+    try:
+        proc = runner(
+            ["aws", "sts", "get-caller-identity"],
+            capture_output=True, text=True,
+        )
+        ok = proc.returncode == 0
+    except FileNotFoundError:
+        return CheckResult(name="aws-auth", ok=False, detail="aws CLI not found")
+    return CheckResult(name="aws-auth", ok=ok, detail="authenticated" if ok else "aws sts failed")

--- a/projects/awsome-ai-gateway/deployment/tui/preflight.py
+++ b/projects/awsome-ai-gateway/deployment/tui/preflight.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import shutil
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
+
+from . import paths
 
 LLM_TOOLS = ["aws", "kubectl", "helm", "terraform", "jq", "python3"]
 TOOL_GW_TOOLS = ["terraform", "aws", "jq", "python3"]
@@ -23,6 +26,30 @@ def check_tools(tools, which=shutil.which) -> list[CheckResult]:
         path = which(t)
         results.append(CheckResult(name=t, ok=path is not None, detail=path or "not found in PATH"))
     return results
+
+
+def check_paths(items) -> list[CheckResult]:
+    """(name, Path) 목록의 존재 여부를 확인. Tool Gateway 워크플로우는 별도
+    PR에서 오는 provision 스크립트/terraform 파일에 의존하므로, 없는 채로
+    워크플로우에 진입해 subprocess가 알 수 없는 에러로 죽는 걸 미리 막는다."""
+    results = []
+    for name, p in items:
+        p = Path(p)
+        results.append(CheckResult(name=name, ok=p.exists(),
+                                   detail=str(p) if p.exists() else f"없음: {p}"))
+    return results
+
+
+# Tool Gateway 워크플로우가 실제로 호출하는 파일들(이 리포에 함께 있어야 동작).
+TOOL_GW_PATHS = [
+    ("provision_tool_gateway.sh", paths.script("provision_tool_gateway.sh")),
+    ("tool-gateway-dev terraform", paths.TOOL_TF_DIR / "main.tf"),
+]
+
+
+def check_tool_gateway_assets() -> list[CheckResult]:
+    """Tool Gateway 배포/삭제에 필요한 스크립트·terraform 존재 확인."""
+    return check_paths(TOOL_GW_PATHS)
 
 
 def check_aws_auth(runner=subprocess.run) -> CheckResult:

--- a/projects/awsome-ai-gateway/deployment/tui/requirements.txt
+++ b/projects/awsome-ai-gateway/deployment/tui/requirements.txt
@@ -1,0 +1,3 @@
+rich>=13.0
+questionary>=2.0
+pytest>=7.4

--- a/projects/awsome-ai-gateway/deployment/tui/runner.py
+++ b/projects/awsome-ai-gateway/deployment/tui/runner.py
@@ -57,6 +57,9 @@ def run_workflow(wf, on_line=None, on_step_done=None, base_env=None,
         results.append(result)
         if on_step_done:
             on_step_done(result)
-        if not result.ok:
-            break  # 실패 시 정지 — 이후 스텝 미실행
+        # skippable 스텝은 실패해도 계속 진행(best-effort). 예: teardown의
+        # helm-uninstall은 릴리스/클러스터가 이미 없으면 non-zero로 끝날 수
+        # 있는데, 그렇다고 뒤따르는 tf-destroy를 건너뛰면 안 된다.
+        if not result.ok and not step.skippable:
+            break  # 필수 스텝 실패 시 정지 — 이후 스텝 미실행
     return results

--- a/projects/awsome-ai-gateway/deployment/tui/runner.py
+++ b/projects/awsome-ai-gateway/deployment/tui/runner.py
@@ -1,0 +1,62 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""Step을 subprocess로 실행하고 stdout을 라인 스트리밍하는 순수 러너.
+
+실제 aws/terraform/helm을 아는 로직이 없다 — argv를 그대로 실행할 뿐이라
+fake 스크립트로 완전히 테스트 가능하다."""
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+
+from .steps import Step
+
+
+@dataclass
+class StepResult:
+    step: Step
+    returncode: int
+    lines: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+def run_step(step: Step, on_line=None, base_env=None) -> StepResult:
+    env = dict(os.environ if base_env is None else base_env)
+    if step.env:
+        env.update(step.env)
+    lines: list[str] = []
+    proc = subprocess.Popen(
+        step.argv,
+        cwd=str(step.cwd) if step.cwd else None,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        line = raw.rstrip("\n")
+        lines.append(line)
+        if on_line:
+            on_line(line)
+    proc.wait()
+    return StepResult(step=step, returncode=proc.returncode, lines=lines)
+
+
+def run_workflow(wf, on_line=None, on_step_done=None, base_env=None,
+                 on_step_start=None) -> list[StepResult]:
+    results: list[StepResult] = []
+    for step in wf:
+        if on_step_start:
+            on_step_start(step)
+        result = run_step(step, on_line=on_line, base_env=base_env)
+        results.append(result)
+        if on_step_done:
+            on_step_done(result)
+        if not result.ok:
+            break  # 실패 시 정지 — 이후 스텝 미실행
+    return results

--- a/projects/awsome-ai-gateway/deployment/tui/runner.py
+++ b/projects/awsome-ai-gateway/deployment/tui/runner.py
@@ -38,11 +38,12 @@ def run_step(step: Step, on_line=None, base_env=None) -> StepResult:
         bufsize=1,
     )
     assert proc.stdout is not None
-    for raw in proc.stdout:
-        line = raw.rstrip("\n")
-        lines.append(line)
-        if on_line:
-            on_line(line)
+    with proc.stdout as out:  # 명시적 close — 다단계 워크플로우에서 FD 누수 방지
+        for raw in out:
+            line = raw.rstrip("\n")
+            lines.append(line)
+            if on_line:
+                on_line(line)
     proc.wait()
     return StepResult(step=step, returncode=proc.returncode, lines=lines)
 

--- a/projects/awsome-ai-gateway/deployment/tui/steps.py
+++ b/projects/awsome-ai-gateway/deployment/tui/steps.py
@@ -1,0 +1,145 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""워크플로우별 Step 시퀀스 정의. 순서 자체가 배포 함정 회피의 핵심."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import paths
+from .config import BackendConfig
+
+
+@dataclass
+class Step:
+    name: str
+    argv: list[str]
+    cwd: Path | None = None
+    env: dict[str, str] | None = None
+    skippable: bool = False
+
+
+def _flags_to_env(flags: dict[str, bool]) -> dict[str, str]:
+    return {k: ("true" if v else "false") for k, v in flags.items()}
+
+
+def build_llm_workflow(*, env: str, backend: BackendConfig,
+                       enable_chat_db_tools: bool, flags: dict[str, bool],
+                       cluster_name: str = "llm-gateway") -> list[Step]:
+    tf_dir = paths.llm_tf_dir(env)
+    wf: list[Step] = []
+
+    # ★함정④: chat_db tools 켜지면 terraform 앞에 Lambda 빌드 선행
+    if enable_chat_db_tools:
+        wf.append(Step("build-lambdas", ["bash", str(paths.BUILD_LAMBDAS_SH)]))
+
+    # ★함정⑤: tf-init에 -backend-config 자동 주입
+    wf.append(Step("tf-init",
+                   ["terraform", "init", "-input=false", "-reconfigure", *backend.backend_args()],
+                   cwd=tf_dir))
+    wf.append(Step("tf-plan", ["terraform", "plan", "-input=false"], cwd=tf_dir))
+    wf.append(Step("tf-apply", ["terraform", "apply", "-auto-approve", "-input=false"], cwd=tf_dir))
+
+    # ★함정③: install-eks에 격리 KUBECONFIG + 실행 플래그 env 주입
+    install_env = {"KUBECONFIG": f"/tmp/{cluster_name}.kubeconfig", **_flags_to_env(flags)}
+    wf.append(Step("install-eks", ["bash", str(paths.script("install-eks.sh")), env],
+                   env=install_env))
+
+    # ★함정⑥: 배포 후 migration 적용 검증 (smoke-test가 db_health 포함 검증)
+    wf.append(Step("verify-migration",
+                   ["bash", str(paths.script("smoke-test.sh")), "--env", env],
+                   skippable=True))
+    return wf
+
+
+def build_tool_workflow(*, backend: BackendConfig, has_key_file: bool) -> list[Step]:
+    tf_dir = paths.TOOL_TF_DIR
+    wf: list[Step] = [
+        Step("tf-init",
+             ["terraform", "init", "-input=false", "-reconfigure", *backend.backend_args()],
+             cwd=tf_dir),
+        Step("tf-apply",
+             ["bash", str(paths.script("provision_tool_gateway.sh")), "deploy"]),
+    ]
+    return wf
+
+
+# ★teardown 순서 함정: helm uninstall(ALB 제거)이 terraform destroy보다 먼저여야
+# orphaned ENI 없이 VPC가 삭제된다. cluster_name/region은 terraform output에서 조회.
+_HELM_UNINSTALL = """\
+set -e
+CL=$(terraform output -raw cluster_name 2>/dev/null) || {
+  echo "cluster_name output 없음 — helm 단계 스킵 (이미 destroy됐거나 미배포)"; exit 0;
+}
+RG=$(terraform output -json | jq -r '.cluster_endpoint.value' | awk -F. '{print $3}')
+echo "cluster=$CL region=$RG"
+aws eks update-kubeconfig --region "$RG" --name "$CL"
+helm uninstall llm-gateway -n llm-gateway || echo "helm release 없음 — ok"
+"""
+
+
+def build_llm_teardown(*, env: str, backend: BackendConfig,
+                       cluster_name: str = "llm-gateway") -> list[Step]:
+    """LLM Gateway 삭제: helm uninstall → terraform destroy (순서가 함정 회피)."""
+    tf_dir = paths.llm_tf_dir(env)
+    return [
+        # ★함정③: 격리 KUBECONFIG. best-effort이므로 skippable.
+        Step("helm-uninstall", ["bash", "-c", _HELM_UNINSTALL],
+             cwd=tf_dir,
+             env={"KUBECONFIG": f"/tmp/{cluster_name}.kubeconfig"},
+             skippable=True),
+        # ★함정⑤: destroy도 backend가 필요 → tf-init에 -backend-config 주입.
+        Step("tf-init",
+             ["terraform", "init", "-input=false", "-reconfigure", *backend.backend_args()],
+             cwd=tf_dir),
+        Step("tf-destroy",
+             ["terraform", "destroy", "-auto-approve", "-input=false"],
+             cwd=tf_dir),
+    ]
+
+
+# AgentCore api-key credential provider 이름 = bare 엔진 키. terraform이
+# `enable_x ? {...} : null`로 이 이름들로 만든다. 다른 스택의 `-creds` 접미
+# provider나 무관한 provider는 절대 건드리지 않도록 이 고정 집합만 정리한다.
+MANAGED_CREDENTIAL_PROVIDERS = (
+    "tavily", "brave", "serper", "exa",
+    "perplexity", "anthropic", "firecrawl", "you",
+)
+
+# ★teardown 드리프트 함정: aws_bedrockagentcore_api_key_credential_provider는
+# provider 미성숙으로 terraform destroy가 AWS 리소스를 못 지우고 state에서만
+# 빠지는 경우가 있다 → 재배포 시 "already exists". destroy 후 이 이름들이 AWS에
+# 남아있으면 control CLI로 삭제한다(best-effort, 존재하는 것만).
+_CRED_PROVIDER_CLEANUP = r"""
+set -e
+REGION="${TOOL_GW_REGION:-us-east-1}"
+MANAGED="{names}"
+existing=$(aws bedrock-agentcore-control list-api-key-credential-providers \
+  --region "$REGION" --query 'credentialProviders[].name' --output text 2>/dev/null || echo "")
+for n in $MANAGED; do
+  # 정확 일치만 삭제. 단어경계 매칭은 '-'를 경계로 취급해 tavily가 tavily-creds에
+  # 오탐되므로, existing의 각 항목과 문자열 완전 일치 비교로 확인한다.
+  found=""
+  for e in $existing; do
+    [ "$e" = "$n" ] && found="yes" && break
+  done
+  if [ -n "$found" ]; then
+    echo "orphan credential provider 삭제: $n"
+    aws bedrock-agentcore-control delete-api-key-credential-provider \
+      --name "$n" --region "$REGION" 2>&1 | head -2 || echo "  (삭제 실패 — 수동 확인 필요: $n)"
+  fi
+done
+echo "credential provider 정리 완료"
+""".replace("{names}", " ".join(MANAGED_CREDENTIAL_PROVIDERS))
+
+
+def build_tool_teardown() -> list[Step]:
+    """Tool Gateway 삭제: provision_tool_gateway.sh teardown (terraform destroy 내장)
+    후, terraform이 못 지운 api-key credential provider orphan을 정리한다."""
+    return [
+        Step("tool-teardown",
+             ["bash", str(paths.script("provision_tool_gateway.sh")), "teardown"]),
+        # ★재발 방지: destroy가 남긴 orphan credential provider 정리 (best-effort)
+        Step("cleanup-credential-providers",
+             ["bash", "-c", _CRED_PROVIDER_CLEANUP],
+             skippable=True),
+    ]

--- a/projects/awsome-ai-gateway/deployment/tui/steps.py
+++ b/projects/awsome-ai-gateway/deployment/tui/steps.py
@@ -39,26 +39,39 @@ def build_llm_workflow(*, env: str, backend: BackendConfig,
     wf.append(Step("tf-plan", ["terraform", "plan", "-input=false"], cwd=tf_dir))
     wf.append(Step("tf-apply", ["terraform", "apply", "-auto-approve", "-input=false"], cwd=tf_dir))
 
-    # ★함정③: install-eks에 격리 KUBECONFIG + 실행 플래그 env 주입
-    install_env = {"KUBECONFIG": f"/tmp/{cluster_name}.kubeconfig", **_flags_to_env(flags)}
+    # ★함정③: install-eks에 격리 KUBECONFIG + 실행 플래그 env 주입.
+    #   install-eks.sh가 이 파일에 kubectl context를 써 넣는다.
+    kubeconfig = f"/tmp/{cluster_name}.kubeconfig"
+    install_env = {"KUBECONFIG": kubeconfig, **_flags_to_env(flags)}
     wf.append(Step("install-eks", ["bash", str(paths.script("install-eks.sh")), env],
                    env=install_env))
 
-    # ★함정⑥: 배포 후 migration 적용 검증 (smoke-test가 db_health 포함 검증)
+    # ★함정⑥+④: 배포 후 migration 적용 검증 (smoke-test가 db_health 포함 검증).
+    #   반드시 install-eks와 동일한 격리 KUBECONFIG를 써야 한다. 안 그러면 기본
+    #   ~/.kube/config(이 계정의 다른 EKS 클러스터로 오염됨)를 봐서 pod를 못 찾고
+    #   "Pod 없음"으로 전부 오탐한다(실제 배포는 정상인데 smoke-test만 FAIL).
     wf.append(Step("verify-migration",
                    ["bash", str(paths.script("smoke-test.sh")), "--env", env],
+                   env={"KUBECONFIG": kubeconfig},
                    skippable=True))
     return wf
 
 
-def build_tool_workflow(*, backend: BackendConfig, has_key_file: bool) -> list[Step]:
+def build_tool_workflow(*, backend: BackendConfig,
+                        key_file: Path | None = None) -> list[Step]:
     tf_dir = paths.TOOL_TF_DIR
+    # ★함정: API 키는 terraform(tfvars/tfstate)을 거치면 안 된다. tfvars에 넣으면
+    #   "undeclared variable" 경고 + 키가 tfstate에 평문 저장된다. provision 스크립트가
+    #   TOOL_KEY_FILE(engine=value 형식)을 읽어 seed-tool-secrets.sh로 Secrets Manager에
+    #   직접 주입하는 게 유일한 정식 경로다.
+    deploy_env = {"TOOL_KEY_FILE": str(key_file)} if key_file else None
     wf: list[Step] = [
         Step("tf-init",
              ["terraform", "init", "-input=false", "-reconfigure", *backend.backend_args()],
              cwd=tf_dir),
         Step("tf-apply",
-             ["bash", str(paths.script("provision_tool_gateway.sh")), "deploy"]),
+             ["bash", str(paths.script("provision_tool_gateway.sh")), "deploy"],
+             env=deploy_env),
     ]
     return wf
 

--- a/projects/awsome-ai-gateway/deployment/tui/tests/__init__.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.

--- a/projects/awsome-ai-gateway/deployment/tui/tests/fixtures/fail.sh
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/fixtures/fail.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "boom" >&2
+exit 1

--- a/projects/awsome-ai-gateway/deployment/tui/tests/fixtures/ok.sh
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/fixtures/ok.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "hello"
+if [ -n "${GREETING:-}" ]; then echo "$GREETING"; fi
+exit 0

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
@@ -1,0 +1,152 @@
+import pytest
+
+pytest.importorskip("rich")
+
+from pathlib import Path
+
+from deployment.tui import cli
+from deployment.tui.preflight import CheckResult
+from deployment.tui.steps import Step
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _step(name, script, *args):
+    return Step(name, ["bash", str(FIX / script), *args])
+
+
+def test_preflight_table_all_ok_true():
+    checks = [CheckResult("aws", True, "/usr/bin/aws"), CheckResult("jq", True, "/usr/bin/jq")]
+    assert cli.preflight_table(checks) is True
+
+
+def test_preflight_table_reports_failure():
+    checks = [CheckResult("aws", True, "ok"), CheckResult("terraform", False, "not found")]
+    assert cli.preflight_table(checks) is False
+
+
+def test_run_and_report_success_over_fake_steps():
+    # fake echo/exit-0 스크립트만 실행 — 실제 배포 없음
+    wf = [_step("first", "ok.sh"), _step("second", "ok.sh")]
+    assert cli.run_and_report(wf, "fake") is True
+
+
+def test_run_and_report_stops_and_reports_failure():
+    wf = [_step("boom", "fail.sh"), _step("never", "ok.sh")]
+    assert cli.run_and_report(wf, "fake") is False
+
+
+def test_aws_account_id_parses_stdout(monkeypatch):
+    import subprocess
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="123456789012\n", stderr=""),
+    )
+    assert cli.aws_account_id() == "123456789012"
+
+
+def test_aws_account_id_none_on_failure(monkeypatch):
+    import subprocess
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=255, stdout="", stderr="denied"),
+    )
+    assert cli.aws_account_id() is None
+
+
+def test_aws_account_id_none_when_cli_missing(monkeypatch):
+    import subprocess
+
+    def boom(*a, **k):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert cli.aws_account_id() is None
+
+
+def test_unwrap_none_raises_cancelled():
+    # questionary .ask()는 Ctrl-C/Esc 시 None → 취소로 변환
+    with pytest.raises(cli.Cancelled):
+        cli._unwrap(None)
+    assert cli._unwrap("dev") == "dev"
+
+
+def test_menu_maps_workflows():
+    labels = [label for label, _ in cli.MENU]
+    handlers = [handler for _, handler in cli.MENU]
+    assert "LLM Gateway 배포" in labels
+    assert cli.flow_llm in handlers
+    assert cli.flow_tool in handlers
+    assert cli.flow_all in handlers
+
+
+def test_flow_all_runs_tool_after_llm_success(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "flow_llm", lambda: calls.append("llm") or True)
+    monkeypatch.setattr(cli, "flow_tool", lambda: calls.append("tool") or True)
+    assert cli.flow_all() is True
+    assert calls == ["llm", "tool"]  # 순서 A→B 고정
+
+
+def test_flow_all_skips_tool_when_llm_fails(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "flow_llm", lambda: calls.append("llm") or False)
+    monkeypatch.setattr(cli, "flow_tool", lambda: calls.append("tool") or True)
+    assert cli.flow_all() is False
+    assert calls == ["llm"]  # A 실패 → B는 게이팅되어 미실행
+
+
+def test_flow_teardown_cancel_runs_nothing(monkeypatch):
+    ran = []
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "__cancel__")
+    monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
+    assert cli.flow_teardown() is False
+    assert ran == []
+
+
+def test_flow_teardown_wrong_token_aborts(monkeypatch):
+    ran = []
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "tool")
+    monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    # 확인 문구를 틀리게 입력 → 삭제 안 함
+    monkeypatch.setattr(cli, "ask_text", lambda msg, default="": "nope")
+    monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
+    assert cli.flow_teardown() is False
+    assert ran == []
+
+
+def test_flow_teardown_correct_token_runs(monkeypatch):
+    ran = []
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "tool")
+    monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    monkeypatch.setattr(cli, "ask_text", lambda msg, default="": "delete tool-gateway")
+    monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
+    assert cli.flow_teardown() is True
+    assert ran == ["Teardown Tool Gateway"]
+
+
+def test_main_menu_exit_does_not_call_str(monkeypatch):
+    # 종료 선택 시 센티널 반환 → 핸들러로 호출하지 않고 정상 종료 (회귀: 'str' not callable)
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "__exit__")
+    cli.main_menu()  # 예외 없이 반환되어야 함
+
+
+def test_main_menu_runs_selected_handler_then_exits(monkeypatch):
+    called = []
+    seq = iter([lambda: called.append("ran"), "__exit__"])
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: next(seq))
+    cli.main_menu()
+    assert called == ["ran"]
+
+
+def test_flow_all_returns_false_when_tool_fails(monkeypatch):
+    # A 성공 + B 실패 → 전체는 False지만 B는 시도됨(non-fatal)
+    calls = []
+    monkeypatch.setattr(cli, "flow_llm", lambda: calls.append("llm") or True)
+    monkeypatch.setattr(cli, "flow_tool", lambda: calls.append("tool") or False)
+    assert cli.flow_all() is False
+    assert calls == ["llm", "tool"]

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
@@ -11,8 +11,8 @@ from deployment.tui.steps import Step
 FIX = Path(__file__).parent / "fixtures"
 
 
-def _step(name, script, *args):
-    return Step(name, ["bash", str(FIX / script), *args])
+def _step(name, script, *args, skippable=False):
+    return Step(name, ["bash", str(FIX / script), *args], skippable=skippable)
 
 
 def test_preflight_table_all_ok_true():
@@ -34,6 +34,12 @@ def test_run_and_report_success_over_fake_steps():
 def test_run_and_report_stops_and_reports_failure():
     wf = [_step("boom", "fail.sh"), _step("never", "ok.sh")]
     assert cli.run_and_report(wf, "fake") is False
+
+
+def test_run_and_report_treats_skippable_failure_as_success():
+    # skippable 스텝이 실패해도 필수 스텝이 모두 통과하면 전체는 성공(완료)
+    wf = [_step("skip", "fail.sh", skippable=True), _step("required", "ok.sh")]
+    assert cli.run_and_report(wf, "fake") is True
 
 
 def test_aws_account_id_parses_stdout(monkeypatch):
@@ -68,6 +74,19 @@ def test_aws_account_id_none_when_cli_missing(monkeypatch):
     assert cli.aws_account_id() is None
 
 
+def test_llm_tfstate_defaults_includes_account_suffix():
+    # 버킷은 S3 전역 유일성 때문에 계정 접미 필수, 락테이블은 접미 없음
+    bucket, table = cli.llm_tfstate_defaults("913524902871")
+    assert bucket == "llm-gateway-vanilla-tfstate-913524902871"
+    assert table == "llm-gateway-vanilla-tflock"
+
+
+def test_llm_tfstate_defaults_fallback_without_account():
+    bucket, table = cli.llm_tfstate_defaults(None)
+    assert bucket == "llm-gateway-vanilla-tfstate"
+    assert table == "llm-gateway-vanilla-tflock"
+
+
 def test_unwrap_none_raises_cancelled():
     # questionary .ask()는 Ctrl-C/Esc 시 None → 취소로 변환
     with pytest.raises(cli.Cancelled):
@@ -100,6 +119,26 @@ def test_flow_all_skips_tool_when_llm_fails(monkeypatch):
     assert calls == ["llm"]  # A 실패 → B는 게이팅되어 미실행
 
 
+def test_flow_tool_aborts_when_assets_missing(monkeypatch):
+    # Tool GW 스크립트/terraform이 없으면 실제 배포 스텝 없이 즉시 중단
+    ran = []
+    monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    monkeypatch.setattr(cli, "tool_gateway_assets_ok", lambda: False)
+    monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
+    assert cli.flow_tool() is False
+    assert ran == []
+
+
+def test_flow_teardown_tool_aborts_when_assets_missing(monkeypatch):
+    ran = []
+    monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "tool")
+    monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    monkeypatch.setattr(cli, "tool_gateway_assets_ok", lambda: False)
+    monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
+    assert cli.flow_teardown() is False
+    assert ran == []
+
+
 def test_flow_teardown_cancel_runs_nothing(monkeypatch):
     ran = []
     monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "__cancel__")
@@ -112,6 +151,7 @@ def test_flow_teardown_wrong_token_aborts(monkeypatch):
     ran = []
     monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "tool")
     monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    monkeypatch.setattr(cli, "tool_gateway_assets_ok", lambda: True)
     # 확인 문구를 틀리게 입력 → 삭제 안 함
     monkeypatch.setattr(cli, "ask_text", lambda msg, default="": "nope")
     monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
@@ -123,6 +163,7 @@ def test_flow_teardown_correct_token_runs(monkeypatch):
     ran = []
     monkeypatch.setattr(cli, "ask_select", lambda msg, choices: "tool")
     monkeypatch.setattr(cli, "run_preflight", lambda tools: True)
+    monkeypatch.setattr(cli, "tool_gateway_assets_ok", lambda: True)
     monkeypatch.setattr(cli, "ask_text", lambda msg, default="": "delete tool-gateway")
     monkeypatch.setattr(cli, "run_and_report", lambda wf, title: ran.append(title) or True)
     assert cli.flow_teardown() is True

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_config.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_config.py
@@ -25,10 +25,133 @@ def test_parse_tfvars_roundtrip():
     assert parsed["env"] == "dev"
 
 
+def test_to_tfvars_nested_dict_block():
+    # dict 값은 평평한 key=value가 아니라 중첩 블록으로 직렬화돼야 한다.
+    out = config.to_tfvars(
+        {
+            "eks_access_entries": {
+                "developer": {
+                    "principal_arn": "arn:aws:iam::1:user/x",
+                    "policy_associations": {
+                        "admin": {"access_scope": {"type": "cluster"}}
+                    },
+                }
+            },
+            "tags": {"CostCenter": "platform-ai"},
+        }
+    )
+    assert "eks_access_entries = {" in out
+    assert "developer = {" in out
+    assert 'principal_arn = "arn:aws:iam::1:user/x"' in out
+    assert 'type = "cluster"' in out
+    assert "tags = {" in out
+    assert 'CostCenter = "platform-ai"' in out
+    # 최상위에 새어나온 scalar가 없어야 함
+    assert "\nprincipal_arn = " not in out
+    assert "\ntype = " not in out
+    assert "\nCostCenter = " not in out
+
+
+def test_parse_tfvars_skips_nested_block_keys():
+    # 중첩 블록 내부의 principal_arn/type/CostCenter는 최상위로 승격되면 안 된다.
+    text = (
+        'project = "llm-gateway"\n'
+        "eks_access_entries = {\n"
+        "  developer = {\n"
+        '    principal_arn = "arn:aws:iam::1:user/x"\n'
+        "    policy_associations = {\n"
+        "      admin = {\n"
+        '        policy_arn = "arn:aws:eks::aws:cluster-access-policy/X"\n'
+        "        access_scope = {\n"
+        '          type = "cluster"\n'
+        "        }\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+        "tags = {\n"
+        '  CostCenter = "platform-ai"\n'
+        "}\n"
+        'environment = "dev"\n'
+    )
+    parsed = config.parse_tfvars(text)
+    assert parsed == {"project": "llm-gateway", "environment": "dev"}
+    for leaked in ("principal_arn", "policy_arn", "type", "CostCenter", "access_scope"):
+        assert leaked not in parsed
+
+
+def test_prefill_scalar_reads_nested_value():
+    text = (
+        "eks_access_entries = {\n"
+        "  developer = {\n"
+        '    principal_arn = "arn:aws:iam::1:user/x"\n'
+        "  }\n"
+        "}\n"
+    )
+    assert config.prefill_scalar(text, "principal_arn") == "arn:aws:iam::1:user/x"
+    assert config.prefill_scalar(text, "missing") == ""
+
+
+def test_tfvars_write_parse_roundtrip_stable():
+    # cli.py가 만드는 구조를 직렬화→파싱→재직렬화해도 최상위 scalar 오염이 없어야 한다.
+    values = {
+        "project": "llm-gateway",
+        "aws_region": "ap-northeast-2",
+        "eks_access_entries": {
+            "developer": {
+                "principal_arn": "arn:aws:iam::1:user/x",
+                "policy_associations": {
+                    "admin": {
+                        "policy_arn": "arn:aws:eks::aws:cluster-access-policy/X",
+                        "access_scope": {"type": "cluster"},
+                    }
+                },
+            }
+        },
+        "tags": {"CostCenter": "platform-ai", "Owner": "team"},
+    }
+    text = config.to_tfvars(values)
+    reparsed = config.parse_tfvars(text)
+    # 재파싱은 최상위 scalar만 — 블록 키가 새어나오면 안 됨
+    assert reparsed == {"project": "llm-gateway", "aws_region": "ap-northeast-2"}
+
+
 def test_write_tfvars(tmp_path):
     p = tmp_path / "terraform.tfvars"
     config.write_tfvars(p, {"env": "dev"})
     assert 'env = "dev"' in p.read_text()
+
+
+def test_to_key_file_uses_seed_script_format():
+    # seed-tool-secrets.sh는 `engine=value` 줄을 IFS='=' 로 읽는다
+    out = config.to_key_file({"tavily": "tvly-abc", "brave": "BSA-xyz"})
+    assert "tavily=tvly-abc\n" in out
+    assert "brave=BSA-xyz\n" in out
+
+
+def test_to_key_file_skips_empty_values():
+    out = config.to_key_file({"tavily": "tvly-abc", "brave": ""})
+    assert "tavily=tvly-abc\n" in out
+    assert "brave" not in out
+
+
+def test_write_key_file_is_0600_and_has_content():
+    import os
+    import stat
+
+    p = config.write_key_file({"exa": "d89a33"})
+    try:
+        assert p.read_text() == "exa=d89a33\n"
+        mode = stat.S_IMODE(os.stat(p).st_mode)
+        assert mode == 0o600  # 평문 키 파일 — 소유자만 읽기
+    finally:
+        p.unlink()
+
+
+def test_write_key_file_returns_none_when_no_keys():
+    # DuckDuckGo만 켠 경우처럼 키가 하나도 없으면 파일을 만들지 않는다
+    assert config.write_key_file({}) is None
+    assert config.write_key_file({"brave": ""}) is None
 
 
 def test_backend_config_args():

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_config.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_config.py
@@ -1,0 +1,50 @@
+from deployment.tui import config
+
+
+def test_to_tfvars_types():
+    out = config.to_tfvars({"project": "llm-gateway", "enable_x": True, "arns": ["a", "b"]})
+    assert 'project = "llm-gateway"' in out
+    assert "enable_x = true" in out
+    assert 'arns = ["a", "b"]' in out
+
+
+def test_find_placeholders_flags_change_me():
+    vals = {"cognito_domain_suffix": "vanilla-auth-CHANGE_ACCOUNT_ID", "ok": "real"}
+    assert config.find_placeholders(vals) == ["cognito_domain_suffix"]
+
+
+def test_find_placeholders_empty_when_clean():
+    assert config.find_placeholders({"a": "real", "b": "123456789012"}) == []
+
+
+def test_parse_tfvars_roundtrip():
+    text = 'project = "llm-gateway"\nenable_x = true\n# comment\n\nenv = "dev"'
+    parsed = config.parse_tfvars(text)
+    assert parsed["project"] == "llm-gateway"
+    assert parsed["enable_x"] is True
+    assert parsed["env"] == "dev"
+
+
+def test_write_tfvars(tmp_path):
+    p = tmp_path / "terraform.tfvars"
+    config.write_tfvars(p, {"env": "dev"})
+    assert 'env = "dev"' in p.read_text()
+
+
+def test_backend_config_args():
+    bc = config.BackendConfig(bucket="llm-gateway-tfstate-123", dynamodb_table="llm-gateway-tflock")
+    assert bc.backend_args() == [
+        "-backend-config=bucket=llm-gateway-tfstate-123",
+        "-backend-config=dynamodb_table=llm-gateway-tflock",
+    ]
+
+
+def test_backend_config_omits_region_when_empty():
+    # region 미지정 시 backend.tf 하드코딩 region을 쓰도록 -backend-config에 추가 안 함
+    bc = config.BackendConfig(bucket="b", dynamodb_table="t")
+    assert not any(a.startswith("-backend-config=region=") for a in bc.backend_args())
+
+
+def test_backend_config_injects_region_when_set():
+    bc = config.BackendConfig(bucket="b", dynamodb_table="t", region="us-west-2")
+    assert "-backend-config=region=us-west-2" in bc.backend_args()

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_paths.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_paths.py
@@ -1,0 +1,18 @@
+from deployment.tui import paths
+
+
+def test_scripts_dir_contains_install_eks():
+    assert (paths.SCRIPTS_DIR / "install-eks.sh").is_file()
+
+
+def test_llm_tf_dir_uses_env():
+    assert paths.llm_tf_dir("dev").name == "llm-gateway-dev"
+    assert paths.llm_tf_dir("prod").name == "llm-gateway-prod"
+
+
+def test_tool_tf_dir_exists():
+    assert paths.TOOL_TF_DIR.name == "tool-gateway-dev"
+
+
+def test_build_lambdas_script_exists():
+    assert paths.BUILD_LAMBDAS_SH.is_file()

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_preflight.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_preflight.py
@@ -18,3 +18,22 @@ def test_check_aws_auth_ok():
 def test_check_aws_auth_fail():
     fake_run = lambda *a, **k: SimpleNamespace(returncode=255)
     assert preflight.check_aws_auth(runner=fake_run).ok is False
+
+
+def test_check_paths_reports_existing_and_missing(tmp_path):
+    exists = tmp_path / "here.sh"
+    exists.write_text("#!/bin/sh\n")
+    missing = tmp_path / "gone.tf"
+    results = preflight.check_paths([("here", exists), ("gone", missing)])
+    by_name = {r.name: r for r in results}
+    assert by_name["here"].ok is True
+    assert by_name["gone"].ok is False
+    assert str(missing) in by_name["gone"].detail
+
+
+def test_check_tool_gateway_assets_returns_checks():
+    # 실제 리포 상태와 무관하게 (name, ok) 쌍을 반환해야 함
+    results = preflight.check_tool_gateway_assets()
+    names = {r.name for r in results}
+    assert "provision_tool_gateway.sh" in names
+    assert "tool-gateway-dev terraform" in names

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_preflight.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_preflight.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+from deployment.tui import preflight
+
+
+def test_check_tools_reports_missing():
+    fake_which = lambda name: "/usr/bin/aws" if name == "aws" else None
+    results = preflight.check_tools(["aws", "helm"], which=fake_which)
+    by_name = {r.name: r for r in results}
+    assert by_name["aws"].ok is True
+    assert by_name["helm"].ok is False
+
+
+def test_check_aws_auth_ok():
+    fake_run = lambda *a, **k: SimpleNamespace(returncode=0)
+    assert preflight.check_aws_auth(runner=fake_run).ok is True
+
+
+def test_check_aws_auth_fail():
+    fake_run = lambda *a, **k: SimpleNamespace(returncode=255)
+    assert preflight.check_aws_auth(runner=fake_run).ok is False

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_runner.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_runner.py
@@ -7,8 +7,8 @@ from deployment.tui.steps import Step
 FIX = Path(__file__).parent / "fixtures"
 
 
-def _mkstep(name, script, *args, env=None):
-    return Step(name, ["bash", str(FIX / script), *args], env=env)
+def _mkstep(name, script, *args, env=None, skippable=False):
+    return Step(name, ["bash", str(FIX / script), *args], env=env, skippable=skippable)
 
 
 def test_run_step_captures_lines_and_success():
@@ -40,3 +40,24 @@ def test_run_workflow_stops_on_failure():
     results = runner.run_workflow(wf)
     assert len(results) == 1
     assert results[0].ok is False
+
+
+def test_run_workflow_continues_past_skippable_failure():
+    # ★함정: teardown의 helm-uninstall은 릴리스/클러스터가 없으면 실패할 수
+    # 있는데, skippable이므로 뒤따르는 tf-destroy는 반드시 실행되어야 한다.
+    wf = [_mkstep("skip-fail", "fail.sh", skippable=True), _mkstep("after", "ok.sh")]
+    results = runner.run_workflow(wf)
+    assert len(results) == 2
+    assert results[0].ok is False and results[0].step.skippable is True
+    assert results[1].step.name == "after" and results[1].ok is True
+
+
+def test_run_workflow_still_stops_on_non_skippable_failure_after_skippable():
+    # skippable 통과 후 필수 스텝이 실패하면 거기서 정지해야 한다.
+    wf = [
+        _mkstep("skip-fail", "fail.sh", skippable=True),
+        _mkstep("required-fail", "fail.sh"),
+        _mkstep("never", "ok.sh"),
+    ]
+    results = runner.run_workflow(wf)
+    assert [r.step.name for r in results] == ["skip-fail", "required-fail"]

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_runner.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_runner.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+from deployment.tui import runner
+from deployment.tui.steps import Step
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _mkstep(name, script, *args, env=None):
+    return Step(name, ["bash", str(FIX / script), *args], env=env)
+
+
+def test_run_step_captures_lines_and_success():
+    result = runner.run_step(_mkstep("ok", "ok.sh"))
+    assert result.ok is True
+    assert any("hello" in ln for ln in result.lines)
+
+
+def test_run_step_streams_via_callback():
+    seen = []
+    runner.run_step(_mkstep("ok", "ok.sh"), on_line=seen.append)
+    assert any("hello" in ln for ln in seen)
+
+
+def test_run_step_reports_failure():
+    result = runner.run_step(_mkstep("fail", "fail.sh"))
+    assert result.ok is False
+    assert result.returncode == 1
+
+
+def test_run_step_merges_env():
+    # ok.sh echoes $GREETING if set
+    result = runner.run_step(_mkstep("ok", "ok.sh", env={"GREETING": "yo"}))
+    assert any("yo" in ln for ln in result.lines)
+
+
+def test_run_workflow_stops_on_failure():
+    wf = [_mkstep("fail", "fail.sh"), _mkstep("never", "ok.sh")]
+    results = runner.run_workflow(wf)
+    assert len(results) == 1
+    assert results[0].ok is False

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_steps.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_steps.py
@@ -1,0 +1,125 @@
+from deployment.tui import steps
+from deployment.tui.config import BackendConfig
+
+BE = BackendConfig(bucket="b", dynamodb_table="t")
+
+
+def _names(wf):
+    return [s.name for s in wf]
+
+
+def test_llm_workflow_includes_build_lambdas_when_chat_db_enabled():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=True, flags={})
+    assert "build-lambdas" in _names(wf)
+
+
+def test_llm_workflow_omits_build_lambdas_when_chat_db_disabled():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False, flags={})
+    assert "build-lambdas" not in _names(wf)
+
+
+def test_tf_init_injects_backend_config():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False, flags={})
+    tf_init = next(s for s in wf if s.name == "tf-init")
+    assert "-backend-config=bucket=b" in tf_init.argv
+    assert "-backend-config=dynamodb_table=t" in tf_init.argv
+
+
+def test_install_eks_isolates_kubeconfig():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False,
+                                  flags={}, cluster_name="my-cluster")
+    install = next(s for s in wf if s.name == "install-eks")
+    assert install.env["KUBECONFIG"] == "/tmp/my-cluster.kubeconfig"
+
+
+def test_install_eks_passes_flags_as_env():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False,
+                                  flags={"DEBUG_MODE": True, "MIGRATION_ENABLED": False})
+    install = next(s for s in wf if s.name == "install-eks")
+    assert install.env["DEBUG_MODE"] == "true"
+    assert install.env["MIGRATION_ENABLED"] == "false"
+
+
+def test_llm_workflow_order():
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=True, flags={})
+    names = _names(wf)
+    assert names.index("build-lambdas") < names.index("tf-init")
+    assert names.index("tf-apply") < names.index("install-eks")
+    assert names.index("install-eks") < names.index("verify-migration")
+
+
+def test_tool_workflow_order():
+    wf = steps.build_tool_workflow(backend=BE, has_key_file=False)
+    names = _names(wf)
+    assert names.index("tf-init") < names.index("tf-apply")
+
+
+def test_llm_teardown_order_helm_before_destroy():
+    # ★함정: helm uninstall(ALB 제거)이 terraform destroy보다 먼저여야 VPC가 지워진다
+    wf = steps.build_llm_teardown(env="dev", backend=BE)
+    names = _names(wf)
+    assert names.index("helm-uninstall") < names.index("tf-init")
+    assert names.index("tf-init") < names.index("tf-destroy")
+
+
+def test_llm_teardown_isolates_kubeconfig_and_is_skippable():
+    wf = steps.build_llm_teardown(env="dev", backend=BE, cluster_name="my-cluster")
+    helm = next(s for s in wf if s.name == "helm-uninstall")
+    assert helm.env["KUBECONFIG"] == "/tmp/my-cluster.kubeconfig"
+    assert helm.skippable is True  # best-effort — 릴리스 없어도 destroy는 진행
+
+
+def test_llm_teardown_destroy_injects_backend():
+    wf = steps.build_llm_teardown(env="dev", backend=BE)
+    tf_init = next(s for s in wf if s.name == "tf-init")
+    assert "-backend-config=bucket=b" in tf_init.argv
+
+
+def test_tool_teardown_calls_provision_script():
+    wf = steps.build_tool_teardown()
+    assert wf[0].name == "tool-teardown"
+    assert "teardown" in wf[0].argv
+
+
+def test_tool_teardown_cleans_up_credential_providers_after_destroy():
+    # ★재발 방지: destroy 후 orphan credential provider 정리 스텝이 뒤따라야 함
+    wf = steps.build_tool_teardown()
+    names = _names(wf)
+    assert names == ["tool-teardown", "cleanup-credential-providers"]
+    cleanup = wf[1]
+    assert cleanup.skippable is True  # best-effort — 없으면 조용히 통과
+
+
+def test_cleanup_targets_only_managed_provider_names():
+    # 다른 스택의 `-creds` 접미 provider나 무관 provider를 오삭제하면 안 됨
+    wf = steps.build_tool_teardown()
+    script = wf[1].argv[-1]
+    for name in steps.MANAGED_CREDENTIAL_PROVIDERS:
+        assert name in script
+    # 문자열 완전 일치 비교로 부분일치 오삭제 방지 (grep -w는 '-'를 경계로 오탐)
+    assert '[ "$e" = "$n" ]' in script
+    assert "grep -w" not in script
+    # 이 스택이 만들지 않는 이름은 정리 대상에 없어야 함
+    assert "brave-creds" not in steps.MANAGED_CREDENTIAL_PROVIDERS
+    assert "NasaInsightAPIKey" not in steps.MANAGED_CREDENTIAL_PROVIDERS
+
+
+def test_cleanup_exact_match_does_not_target_creds_suffix():
+    # tavily가 tavily-creds에 오탐되지 않도록 완전 일치 로직 검증 (실 셸 실행)
+    import subprocess
+
+    script = steps.build_tool_teardown()[1].argv[-1]
+    # aws를 가짜로 대체: list는 -creds 이름만 반환, delete 호출은 기록
+    harness = (
+        'aws() {\n'
+        '  if [ "$2" = "list-api-key-credential-providers" ]; then\n'
+        '    echo "NasaInsightAPIKey brave-creds tavily-creds"; return 0; fi\n'
+        '  if [ "$2" = "delete-api-key-credential-provider" ]; then\n'
+        '    echo "DELETE_CALLED $4"; return 0; fi\n'
+        '}\n'
+    )
+    out = subprocess.run(
+        ["bash", "-c", harness + script],
+        capture_output=True, text=True,
+    ).stdout
+    assert "DELETE_CALLED" not in out  # -creds 이름은 절대 삭제 대상 아님

--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_steps.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_steps.py
@@ -32,6 +32,15 @@ def test_install_eks_isolates_kubeconfig():
     assert install.env["KUBECONFIG"] == "/tmp/my-cluster.kubeconfig"
 
 
+def test_verify_migration_shares_install_kubeconfig():
+    # smoke-test 스텝도 install-eks와 동일 격리 KUBECONFIG를 써야 한다. 없으면
+    # 기본 ~/.kube/config(다른 클러스터로 오염됨)를 봐서 pod를 못 찾고 오탐한다.
+    wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False,
+                                  flags={}, cluster_name="my-cluster")
+    verify = next(s for s in wf if s.name == "verify-migration")
+    assert verify.env["KUBECONFIG"] == "/tmp/my-cluster.kubeconfig"
+
+
 def test_install_eks_passes_flags_as_env():
     wf = steps.build_llm_workflow(env="dev", backend=BE, enable_chat_db_tools=False,
                                   flags={"DEBUG_MODE": True, "MIGRATION_ENABLED": False})
@@ -49,9 +58,26 @@ def test_llm_workflow_order():
 
 
 def test_tool_workflow_order():
-    wf = steps.build_tool_workflow(backend=BE, has_key_file=False)
+    wf = steps.build_tool_workflow(backend=BE)
     names = _names(wf)
     assert names.index("tf-init") < names.index("tf-apply")
+
+
+def test_tool_workflow_injects_key_file_env_not_tfvars():
+    # ★함정: API 키는 tfvars가 아니라 TOOL_KEY_FILE env로만 넘어가야 한다
+    #   (tfstate 평문 저장 + undeclared variable 경고 방지).
+    from pathlib import Path
+
+    wf = steps.build_tool_workflow(backend=BE, key_file=Path("/tmp/keys.env"))
+    apply = next(s for s in wf if s.name == "tf-apply")
+    assert apply.env["TOOL_KEY_FILE"] == "/tmp/keys.env"
+
+
+def test_tool_workflow_no_key_file_leaves_env_unset():
+    # 키가 없으면(예: DuckDuckGo만) TOOL_KEY_FILE을 주입하지 않는다 → seed 스킵.
+    wf = steps.build_tool_workflow(backend=BE)
+    apply = next(s for s in wf if s.name == "tf-apply")
+    assert apply.env is None
 
 
 def test_llm_teardown_order_helm_before_destroy():

--- a/projects/awsome-ai-gateway/docs/superpowers/specs/2026-07-12-deploy-tui-drift-resilience-design.md
+++ b/projects/awsome-ai-gateway/docs/superpowers/specs/2026-07-12-deploy-tui-drift-resilience-design.md
@@ -1,0 +1,150 @@
+# Deploy TUI — 재배포 drift 근본 제거 설계
+
+날짜: 2026-07-12
+상태: 승인됨 (구현 대기)
+
+## 배경 / 문제
+
+deploy-tui 로 dev 스택을 배포하다 아래 3종 에러가 연쇄로 발생했다. 모두
+"이전 apply/teardown 의 잔재(drift)"가 재배포를 막는 재현성 있는 함정이며,
+사용자 환경뿐 아니라 **teardown→재배포하거나 apply 도중 프로세스가 죽는 누구든**
+동일하게 겪는다.
+
+| # | 에러 | 스텝 |
+|---|------|------|
+| 1 | `Error acquiring the state lock` (DynamoDB stale lock) | tf-plan |
+| 2 | `cannot re-use a name that is still in use` (helm `alb_controller` `pending-install`) | tf-apply |
+| 3 | `secret ... already scheduled for deletion` (`chat-agent/reader`) | tf-apply |
+
+목표: **진단/안내 같은 반창고가 아니라, drift 가 애초에 생기지 않도록 소스에서
+근본 원인을 제거한다.**
+
+## 근본 원인
+
+두 뿌리로 갈린다.
+
+### 원인 A — terraform 설정 결함 (에러 #3)
+`modules/agentcore-runtime/lambdas.tf` 의 `aws_secretsmanager_secret.chat_reader`
+에만 `recovery_window_in_days` 가 **누락**되어 기본값 30일이 적용된다. 형제
+secret 4개는 모두 `recovery_window_in_days = 0` 이다:
+
+- `modules/elasticache-valkey/main.tf` (auth_token)
+- `modules/aurora-postgresql/secrets.tf` (gateway_user, db)
+- `modules/tool-gateway/tool-secret/main.tf` (this)
+
+그래서 teardown 시 `chat_reader` 만 30일간 "scheduled for deletion" 으로 남고,
+그 안에 재배포하면 같은 이름 재생성이 불가해 `InvalidRequestException` 이 뜬다.
+**teardown→재배포하는 누구나 100% 재현.** 한 줄로 영구 제거되는 진짜 결함.
+
+### 원인 B — apply 중단 시 잔재 (에러 #1, #2)
+`runner.py` 의 `run_step` 은 subprocess 를 `Popen` 으로 띄운 뒤 stdout 을 읽는데,
+`KeyboardInterrupt`(Ctrl+C) 나 프로세스 종료가 오면 **자식 terraform 에게 정리할
+기회를 주지 않고** 예외만 전파한다. 그 결과:
+
+- terraform 이 DynamoDB state lock 을 풀지 못하고 죽음 → 에러 #1
+- helm provider 는 `atomic=true, cleanup_on_fail=true` 라 **정상 실패 시엔 스스로
+  롤백**하지만, 강제 종료되면 롤백할 틈이 없어 `pending-install` 릴리스가 박제됨
+  → 에러 #2
+
+즉 B 의 뿌리는 하나: **TUI 가 중단될 때 자식 프로세스에 graceful 종료 신호를
+전달하지 않는다.** terraform 은 SIGINT 를 받으면 현재 작업을 마무리하고 lock 을
+스스로 해제하도록 설계돼 있으므로, 신호만 제대로 전달하면 #1, #2 가 소스에서
+사라진다.
+
+## 설계
+
+### 수정 1 — chat_reader recovery_window (원인 A)
+
+`modules/agentcore-runtime/lambdas.tf` 의 `chat_reader` 에 형제들과 동일하게
+추가:
+
+```hcl
+resource "aws_secretsmanager_secret" "chat_reader" {
+  count                   = local.db_tools_enabled
+  name                    = "/${var.project}/${var.environment}/chat-agent/reader"
+  description             = "..."
+  kms_key_id              = aws_kms_key.chat_agent.arn
+  recovery_window_in_days = 0   # ← 추가: teardown 시 즉시 완전 삭제 (형제 secret 과 일치)
+
+  tags = merge(var.tags, { Name = "${local.name_prefix}-reader-secret" })
+}
+```
+
+효과: teardown 이 secret 을 복구윈도우 없이 즉시 삭제 → 재배포 시 이름 충돌 없음.
+dev 편의 설정이며 형제 4개가 이미 동일하므로 일관성도 맞다.
+
+### 수정 2 — runner.py graceful shutdown (원인 B)
+
+`run_step` 이 자식을 **process group leader** 로 띄우고(`start_new_session=True`),
+`KeyboardInterrupt` 를 받으면 그룹 전체에 SIGINT 를 보내 정리를 기다린다. grace
+시간 내 안 끝나면 SIGTERM→SIGKILL 로 에스컬레이션한다.
+
+```python
+import signal
+
+GRACE_SECONDS = 30  # terraform 이 SIGINT 후 lock 해제 + 현재 리소스 마무리할 여유
+
+def run_step(step, on_line=None, base_env=None):
+    env = ...
+    proc = subprocess.Popen(
+        step.argv, cwd=..., env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1,
+        start_new_session=True,   # 자식을 새 프로세스 그룹의 리더로 → 그룹 신호 전파
+    )
+    try:
+        with proc.stdout as out:
+            for raw in out:
+                ...
+        proc.wait()
+    except KeyboardInterrupt:
+        _terminate_gracefully(proc)   # 그룹에 SIGINT → grace 대기 → SIGKILL
+        raise                          # 취소 의도는 상위(main)로 계속 전파
+    return StepResult(...)
+```
+
+`_terminate_gracefully(proc)`:
+1. `os.killpg(os.getpgid(proc.pid), signal.SIGINT)` — terraform/helm 이 lock 해제·
+   atomic 롤백을 수행할 기회를 준다
+2. `proc.wait(timeout=GRACE_SECONDS)` — 정상 종료 대기
+3. 타임아웃이면 `SIGTERM`, 다시 타임아웃이면 `killpg(SIGKILL)` 로 강제 종료
+4. 이미 종료됐으면(ProcessLookupError) 조용히 통과
+
+**경계/인터페이스**
+- `run_step` 의 반환값·시그니처는 그대로 유지 (정상 경로 무변화).
+- graceful 종료 로직은 `_terminate_gracefully` 순수 헬퍼로 분리 → 단독 테스트 가능.
+- `run_workflow`, `cli.py` 는 변경 없음. `main()` 은 이미 `KeyboardInterrupt` 를
+  잡아 "bye" 출력하므로 전파된 예외가 자연스럽게 처리된다.
+
+## 테스트 전략 (TDD)
+
+기존 fixture 철학(fake bash 스크립트) 유지. 실제 aws/terraform 불필요.
+
+**수정 1 (terraform)** — terraform 은 이 리포에서 단위 테스트하지 않으므로,
+정적 보증으로 충분: 형제 secret 과 동일 속성이 있는지 코드 리뷰 + `terraform
+validate`(선택). 회귀 방지용으로 간단한 grep 기반 테스트를 추가할 수 있으나
+YAGNI — 우선 제외.
+
+**수정 2 (runner)** — 새 fixture `sleep.sh`(SIGINT 트랩해서 "cleaned up" 출력 후
+종료 / 또는 무한 sleep) 를 추가하고:
+
+1. `test_terminate_gracefully_sends_sigint_and_reaps` — 오래 도는 자식을
+   `_terminate_gracefully` 로 종료 → 자식이 SIGINT 를 받아 정리 로그를 남기고
+   종료했는지, 프로세스가 확실히 reap 됐는지 확인.
+2. `test_terminate_gracefully_sigkills_after_grace` — SIGINT 를 무시하는 fixture
+   에 대해 grace(테스트에선 짧게 monkeypatch) 후 SIGKILL 로 죽는지 확인.
+3. `test_run_step_normal_path_unchanged` — 기존 ok.sh/fail.sh 동작 회귀 없음
+   (기존 테스트가 이미 커버; 그대로 통과해야 함).
+
+`GRACE_SECONDS` 는 모듈 상수로 두어 테스트에서 monkeypatch 로 짧게 만든다.
+
+## 범위 밖 (YAGNI)
+- 진단/복구 안내 모듈 (`diagnostics.py`): 근본 원인을 제거하므로 불필요.
+- 자동 force-unlock / force-delete: 파괴적이고 동시 실행 apply 를 죽일 위험.
+- helm 모듈 변경: 이미 `atomic + cleanup_on_fail` 이라 손댈 것 없음.
+- 다른 secret 들: 이미 `recovery_window_in_days = 0`.
+
+## 잔여 수동 조치 (이번 세션에서 이미 처리)
+현재 계정의 이미 발생한 drift 3건은 세션 중 수동 정리 완료:
+force-unlock, helm uninstall(pending 릴리스), secret force-delete. 위 수정은
+**앞으로의 재발**을 막는다.


### PR DESCRIPTION
## Summary

Adds a **Deploy TUI** — a thin inline console UI (`rich` + `questionary`, not full-screen) that orchestrates the existing `awsome-ai-gateway` deploy scripts in the correct order.

It does **not** reimplement any deploy logic. It subprocess-calls the existing bash scripts / `terraform` / `build-lambdas.sh` with the right env, args, and tfvars, so the deployment stays a thin orchestration layer over what's already there.

## Why

Deployment has many interdependent options (2 independent stacks in different regions, dev/prod, `install-eks.sh` env flags, per-engine Tool Gateway toggles + API keys). Hand-assembling these via CLI args / env / tfvars is error-prone. The TUI unifies configuration + ordered execution.

## What it does

- **Ordered steps** (`steps.py`) — the sequence itself is how known footguns are avoided:
  - isolated `KUBECONFIG=/tmp/<cluster>.kubeconfig` injection (no `~/.kube/config` pollution)
  - `build-lambdas` inserted before `terraform` when `enable_chat_db_tools=true`
  - `-backend-config` auto-injected into `tf-init`
  - post-deploy migration verification (gateway role + table count)
  - **teardown ordering**: helm uninstall (ALB first) → terraform destroy, so no orphaned ENI blocks VPC deletion; Tool GW destroy → orphan credential-provider cleanup.
- **Config forms → tfvars/env** (`config.py`) — form input serialized to `terraform.tfvars` / env dict, prefill from existing tfvars or `.example`, placeholder validation (`CHANGE_ME`/`ACCOUNT_ID` blocks progress).
- **Pure process runner** (`runner.py`) — subprocess exec + real-time stdout streaming; knows nothing about aws/terraform, so it's fully testable with fake scripts. Honors `skippable` steps (best-effort steps that fail don't abort the workflow).
- **Preflight** (`preflight.py`) — tool/auth checks, plus Tool Gateway asset presence (scripts/terraform) so the flow aborts cleanly with guidance when those files aren't in the repo.
- **Launcher** — `deployment/scripts/deploy-tui.sh` bootstraps the venv and runs `python -m deployment.tui`.

## UI

- Inline (append-only) console via `rich` — does not take over the full screen, so logs stay in the shell scrollback (copy/scroll freely).
- Menu/select: arrow keys ↑↓ + Enter (`questionary`); search-engine multi-select: space to toggle.
- Dependencies: `rich` + `questionary` only.

## Fixes from live teardown validation

Running an actual dev teardown surfaced three defects, now fixed in this PR:

1. **`skippable` was decorative** — `run_workflow` broke on any step failure, so a best-effort `helm-uninstall` (release/cluster already gone → non-zero) would skip the following `terraform destroy` entirely. Runner now continues past skippable failures; the reporter marks them ⚠ and treats a fully-torn-down stack as 완료.
2. **Tool Gateway asset gating** — the Tool GW workflows call `provision_tool_gateway.sh` + `tool-gateway-dev` terraform that arrive via a separate PR. When absent, the flow now aborts cleanly with guidance instead of an opaque subprocess error (LLM GW unaffected).
3. **LLM tfstate defaults** — bucket default was `llm-gateway-tfstate`, but the real backend (and `backend.tf` comment) uses `llm-gateway-vanilla-tfstate-<account>` / `llm-gateway-vanilla-tflock`; the bare name is another account's bucket (AccessDenied/301). Defaults now derive the account suffix via `aws sts`, matching Tool GW's existing pattern.

## Testing

60 unit tests, all passing:

```
python -m pytest deployment/tui/tests -q
60 passed
```

Covers config serialization, step sequencing (conditional include/exclude, teardown order), runner subprocess streaming + exit codes + skippable continue/stop, preflight checks (tools/auth/asset presence), and CLI flow gating.

## Scope note

Independent of the Tool Gateway integration PR. This PR is branched from `main` and contains only the TUI orchestrator (`deployment/tui/` + `deploy-tui.sh`). Tool Gateway menu items detect their missing assets and guide the user rather than failing obscurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
