### PR TITLE
docs(awsome-ai-gateway): add English README + refine Korean README

### DIFF
--- a/projects/awsome-ai-gateway/README.en.md
+++ b/projects/awsome-ai-gateway/README.en.md
@@ -1,0 +1,212 @@
+# AWSome AI Gateway
+
+> ⚠️ **This is a sample/prototype for demonstration purposes only. Not production-ready; review and harden before any production use.**
+
+[한국어 README](README.md)
+
+A unified LLM Gateway for coding agents (Claude Code / Codex / Cowork). Authenticates via OIDC, auto-issues Virtual Keys, and routes each client to the appropriate backend (AWS Bedrock native / Bedrock Mantle). Provides per-team/user/app budget management, rate limiting, model access control, usage tracking (ROI), server-side web search, and a natural-language **AI BI Assistant** for querying operational data.
+
+---
+
+## Architecture
+
+![AWSome AI Gateway Architecture](docs/img/architecture-overview.png)
+
+Authentication, billing, and governance happen at a single gateway. Requests are then routed to different AWS accounts/backends based on the client type. Routing is **data-driven** — determined by `routing_profiles` table rows (Redis-cached, TTL 300s), not code.
+
+```
+[Claude Code]  [Codex]  [Cowork]
+   │  api-key-helper (OIDC token → VK auto-issue; Cowork uses app config)
+   ▼
+[Admin API]  ── OIDC (Cognito) verification → VK issuance (POST /v1/auth/exchange)
+   │
+   ▼
+Client ──Bearer VK──→ [Gateway Proxy] ── Auth · Client ID · Budget · RateLimit · Downgrade
+                              │            → Routing profile → backend dispatch
+                              │
+          ┌───────────────────┼───────────────────────────────┐
+          ▼                    ▼                               ▼
+   claude-code               codex                          cowork
+   Bedrock NATIVE            Bedrock Mantle                 Bedrock Mantle
+   (boto3 invoke_model)      (OpenAI Responses API)         (Anthropic Messages)
+   Cross-account STS         In-account IRSA                Cross-account STS
+   Transparent fallback      httpx AsyncClient              httpx AsyncClient
+          │
+          ▼
+   [Redis] + [Aurora PostgreSQL]   ← Budget / RateLimit / cost stream / aggregation
+
+── Server-side Web Search (Architecture C, routing profile web_search_enabled=True) ──
+Gateway injects web_search tool → intercepts model tool_use → AgentCore Gateway
+managed WebSearch (MCP over httpx, SigV4/IRSA, us-east-1) → re-injects results.
+Zero client-side configuration.
+
+── Operator BI (admin-chat-agent) ──
+[Admin UI /chat] ─SSE─→ [Admin API proxy] ─SigV4─→ [Bedrock AgentCore Runtime]
+                                                      │ agents-as-tools (Strands)
+                                                      │  Orchestrator (Opus)
+                                                      │  ├ SQL Specialist → [query_db Lambda] → Aurora (read-only)
+                                                      │  ├ Code Specialist → Code Interpreter
+                                                      │  ├ SQL Validator
+                                                      │  ├ Viz Specialist → chart spec
+                                                      │  ├ Report Specialist
+                                                      │  └ L3 self-consistency
+                                                      ▼ Real-time streaming (SSE) + heartbeat
+```
+
+> Full component / account / data-plane details: [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`devlog_websearch.md`](devlog_websearch.md).
+
+---
+
+## Demo
+
+| Demo | Link |
+|------|------|
+| AWSome AI Gateway — Overview & Demo ① | [![Demo 1](https://img.youtube.com/vi/vp-Zsb5BocI/0.jpg)](https://youtu.be/vp-Zsb5BocI) |
+| AWSome AI Gateway — Overview & Demo ② | [![Demo 2](https://img.youtube.com/vi/NDDsjHrkXMQ/0.jpg)](https://youtu.be/NDDsjHrkXMQ) |
+
+---
+
+## Key Features
+
+- **Gateway Core** — OIDC → Virtual Key auto-issuance, 3-client × 2 API formats (Anthropic Messages / OpenAI Responses) routing, per-client backend dispatch (Bedrock native / Mantle). Per-team/user/app budgets (HARD_BLOCK / SOFT_WARNING / THROTTLE), rate limits (USER / TEAM / GLOBAL scopes), model ACL, auto-downgrade, usage/ROI aggregation.
+- **Multi-app Governance (Phase 2)** — Per-user model allow-list (overrides team policy), per-user client ACL (restrict which apps a user can access), per-app budget/rate-limit separation. Data-driven routing profiles underpin all governance.
+- **Service Tokens** — Long-lived bearer tokens for external (non-OIDC) systems. Issue / rotate / revoke via admin-api. Only the prefix is stored; full token returned once at issuance.
+- **Resilience** — Readiness gate (`/health/ready`, 503 on degradation), invalid-VK fast rejection (no DB session opened), DB pool tuning (10s `pool_timeout` fast-fail), Redis circuit breaker with in-memory rate-limit fallback, response header leak prevention, security event detector with LRU OOM defense, cost stream spooling on Redis blip.
+- **Server-side Web Search (Architecture C)** — Gateway injects `web_search` tool, intercepts model `tool_use`, calls AgentCore managed WebSearch (MCP/SigV4). Zero client configuration — just ask and get searched answers. Supports both Anthropic/Responses formats.
+- **Admin UI (Next.js 14)** — Dashboard (KPI, cost trends, model/client share donuts, team/user ranking), user/team/model/budget/rate-limit management, real-time monitoring, ROI analysis, `/chat` BI assistant. Light/dark glass design.
+- **AI BI Assistant (`/chat`)** — Natural language → validated SQL (text2SQL) → Aurora query → markdown table + recharts chart. Agents-as-tools orchestrator on AWS Strands + Bedrock AgentCore Runtime. Real-time token streaming + heartbeat.
+
+---
+
+## Security Design
+
+Security is solved structurally, not by configuration:
+
+| Layer | Mechanism | Why it's safe |
+|-------|-----------|---------------|
+| Request body | Whitelist reconstruction (13 allowed fields only) | Arbitrary client fields never reach upstream |
+| Upstream auth | Gateway mints its own credentials (SigV4 / Mantle bearer) | Client key (VK) is never forwarded — auth boundary fully separated |
+| Response headers | Gateway-only injection (budget/rate-limit/request-id) | Upstream headers are not relayed to client |
+| Model/client ACL | Per-user allow-list enforced at middleware layer | Unauthorized model or app access returns 403 |
+| Invalid key flood | Redis-first validation; DB session not opened for invalid keys | Connection pool exhaustion attack neutralized |
+
+This is **re-origination**, not relay. There is no path for headers to leak.
+
+---
+
+## Guides
+
+| Audience | Document | Description |
+|----------|----------|-------------|
+| Deployer (Infra Engineer) | [`guides/deployer-guide.md`](guides/deployer-guide.md) | EKS Fargate deployment, Terraform, Helm, secrets, monitoring |
+| Admin (Operator) | [`guides/admin-guide.md`](guides/admin-guide.md) | User/team management, budgets, rate limits, models, incident response |
+| End User (Developer) | [`guides/user-guide.md`](guides/user-guide.md) | CLI install, login, Claude Code integration, troubleshooting |
+| 3-client Onboarding (all OS) | [`guides/QUICKSTART.md`](guides/QUICKSTART.md) | Claude Code / Codex / Cowork × macOS · Linux · Windows |
+
+Step-by-step deployment: [`deployment/docs/eks-fargate/`](deployment/docs/eks-fargate/). Secrets contract: [`deployment/docs/secrets-contract.md`](deployment/docs/secrets-contract.md).
+
+---
+
+## Services
+
+Helm deploys 6 Deployments + 1 Job. The admin-chat-agent is hosted separately on Bedrock AgentCore Runtime.
+
+| Service | Role |
+|---------|------|
+| **gateway-proxy** | User API entry point. VK auth, client identification, backend routing, rate limiting, Bedrock/Mantle invocation |
+| **admin-api** | Management REST API. OIDC→VK issuance, budget/rate-limit/model CRUD, `/chat` AgentCore proxy |
+| **admin-ui** | Next.js 14 management dashboard |
+| **scheduler** | ROI aggregation + VK expiration cleanup (singleton, reuses admin-api image) |
+| **notification-worker** | Budget threshold alerts (default: mock provider) |
+| **cost-recorder-worker** | Redis Stream → Aurora cost recording + daily aggregation |
+| **migration** | Alembic DB migration (helm pre-install/pre-upgrade Job, head=`0022`) |
+| **admin-chat-agent** | BI assistant on Bedrock AgentCore Runtime (not in EKS). Connected via `AGENTCORE_RUNTIME_ARN` env |
+
+---
+
+## Quick Start (User)
+
+```bash
+# 1. Set environment (provided by your admin)
+export OIDC_ISSUER_URL="..."
+export OIDC_CLIENT_ID="..."
+export ADMIN_API_URL="..."
+export ANTHROPIC_BASE_URL="..."
+
+# 2. Onboard (macOS / Linux)
+bash scripts/onboard-macos-linux.sh
+# With Claude Code auto-setup:
+bash scripts/onboard-macos-linux.sh --setup-claude-code
+
+# 3. Start using
+claude
+```
+
+- **Claude Code**: `gateway-cli setup` creates managed settings (`50-gateway.json`)
+- **Codex**: `~/.codex/config.toml` → `model_provider=gateway`, `wire_api=responses`, `base_url=<BASE>/v1`
+- **Cowork**: App config JSON with 5 keys (`inferenceProvider` / `inferenceGatewayBaseUrl` / `inferenceGatewayApiKey` / `inferenceGatewayAuthScheme` / `inferenceCredentialKind:"static"`)
+
+> Detailed guide: [`guides/QUICKSTART.md`](guides/QUICKSTART.md). Container-isolated execution: [`gateway-clients/README.md`](gateway-clients/README.md).
+
+---
+
+## Quick Start (Operator — BI Assistant)
+
+After logging into Admin UI, use the **Chat** menu (or bottom-right BI Chat button) to query operational data in natural language. Requires ADMIN or TEAM_LEADER role.
+
+```
+Examples:
+  "Show total cost per user this month as a table and chart"
+  "Model call volume trend for the last 30 days"
+  "Teams that reached 80% of budget"
+  "Top user getting 429s in the last 24h"
+```
+
+---
+
+## Project Structure
+
+| Path | Description |
+|------|-------------|
+| `gateway-proxy/` | Data plane (FastAPI, VK auth + client identification + Bedrock/Mantle proxy) |
+| `admin-api/` | Control plane (model/team/budget/VK REST API + scheduler entrypoint) |
+| `admin-ui/` | Next.js 14 management UI (dashboard/monitoring/analysis + `/chat` BI) |
+| `admin-chat-agent/` | BI assistant — Strands agents-as-tools + AgentCore Runtime |
+| `cost-recorder-worker/` | Redis Stream → Aurora cost recorder |
+| `notification-worker/` | Budget threshold alert worker |
+| `db/` | Alembic migration source (head=`0022`) |
+| `gateway-cli/` | User CLI (`gateway-cli`, `api-key-helper`, `statusline`) |
+| `gateway-clients/` | Claude-code/Codex container isolation utilities (`claude-box`/`codex-box` + `gw.sh`) |
+| `scripts/` | Onboarding scripts (macOS/Linux/Windows) + IAM scripts |
+| `deployment/charts/` | Helm chart + values (EKS Fargate dev/prod/loadtest + on-prem dev/prod) |
+| `deployment/terraform/` | Terraform modules (VPC, EKS, Aurora, ElastiCache, Cognito, IRSA, ALB, ESO) |
+| `guides/` | Final guides (deployer/admin/user/quickstart) |
+
+---
+
+## Original Builders
+
+| Name | Role | Contact |
+|------|------|---------|
+| **Kyutae Park, Ph.D.** | AWS AI Specialist Solutions Architect | [Email](mailto:kyutae@amazon.com) |
+| **Minjae An** | AWS Forward Deployed DL Architect | [Email](mailto:aminjae@amazon.com) |
+| **Sue Cha** | AWS Deep Learning Architect | [Email](mailto:suecha@amazon.com) |
+| **Gonsoo Moon** | AWS Sr. AI Specialist Solutions Architect | [Email](mailto:moongons@amazon.com) |
+
+## Contributors
+
+| Name | Role | Contact |
+|------|------|---------|
+| **Charlie Chang** | AWS Sr. Generative AI Strategist | [Email](mailto:subchang@amazon.com) |
+| **Yash Shah** | AWS Data Science Manager | [Email](mailto:syash@amazon.com) |
+| **Youngjoon Choi** | AWS Sr. AI Specialist Solutions Architect Manager | [Email](mailto:choijoon@amazon.com) |
+
+---
+
+**Built with ❤️ by AWS Specialist SA Team and GenAIIC**
+
+---
+
+## License
+
+This sample code is made available under a modified MIT license (MIT-0). See the [LICENSE](LICENSE) file.

--- a/projects/awsome-ai-gateway/README.md
+++ b/projects/awsome-ai-gateway/README.md
@@ -35,11 +35,11 @@
    claude-code               codex                          cowork
    Bedrock NATIVE            Bedrock Mantle                 Bedrock Mantle
    (boto3 invoke_model)      (OpenAI Responses API)         (Anthropic Messages)
-   계정 374445650473          계정 859 in-account             계정 905418156477
+   계정 <CLAUDE-CODE-ACCOUNT-ID>          계정 <MAIN-ACCOUNT-ID> in-account             계정 <COWORK-ACCOUNT-ID>
    (ap-northeast-2)          (us-east-2, 오하이오)           (ap-northeast-1, 도쿄)
    STS AssumeRole(374 role)  assume 없음 — pod IRSA 직접      STS AssumeRole(905 role)
    ExternalId=claude-code-…  Mantle GPT-5.5                 ExternalId=cowork-…
-   실패 시 859 in-account     bearer(BedrockTokenGenerator)   Opus 4.8 (cowork-opus)
+   실패 시 메인 계정 in-account     bearer(BedrockTokenGenerator)   Opus 4.8 (cowork-opus)
    투명 폴백(절대 안 죽음)     httpx AsyncClient               httpx AsyncClient
           │
           ▼
@@ -67,10 +67,10 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 | 항목 | 계정 | region | 백엔드 | API 규격 | cross-account |
 |------|------|--------|--------|------|---------------|
-| 메인 배포 (게이트웨이 전 서비스 + Aurora + AgentCore Runtime/웹서치 GW + ECR) | `859741818597` | ap-northeast-2 | — | — | gateway-proxy IRSA 가 이 계정 |
-| claude-code | `374445650473` | ap-northeast-2 | Bedrock NATIVE (invoke_model) | Anthropic Messages | STS AssumeRole(ExternalId=`claude-code-bedrock`), 실패 시 859 in-account 투명 폴백 |
-| codex | `859741818597` (in-account) | us-east-2 | Bedrock Mantle GPT-5.5 | OpenAI Responses (`/v1/responses`) | 없음 — pod IRSA creds 직접 사용 |
-| cowork | `905418156477` | ap-northeast-1 | Bedrock Mantle Opus 4.8 | Anthropic Messages | STS AssumeRole(ExternalId=`cowork-bedrock`) |
+| 메인 배포 (게이트웨이 전 서비스 + Aurora + AgentCore Runtime/웹서치 GW + ECR) | `<MAIN-ACCOUNT-ID>` | ap-northeast-2 | — | — | gateway-proxy IRSA 가 이 계정 |
+| claude-code | `<CLAUDE-CODE-ACCOUNT-ID>` | ap-northeast-2 | Bedrock NATIVE (invoke_model) | Anthropic Messages | STS AssumeRole(ExternalId=`claude-code-bedrock`), 실패 시 메인 계정 in-account 투명 폴백 |
+| codex | `<MAIN-ACCOUNT-ID>` (in-account) | us-east-2 | Bedrock Mantle GPT-5.5 | OpenAI Responses (`/v1/responses`) | 없음 — pod IRSA creds 직접 사용 |
+| cowork | `<COWORK-ACCOUNT-ID>` | ap-northeast-1 | Bedrock Mantle Opus 4.8 | Anthropic Messages | STS AssumeRole(ExternalId=`cowork-bedrock`) |
 
 - cross-account는 `STS AssumeRole(DurationSeconds=3600)` + 선택적 `ExternalId`. claude-code(374 native)의 클라이언트는 `BedrockAccountClientProvider`가 `(role_arn, region, external_id)` 키로 vend/캐시합니다. assume 실패 시 게이트웨이는 859 in-account 클라이언트로 투명 폴백하므로 claude-code 요청은 죽지 않습니다.
 - codex/cowork Mantle bearer는 `MantleCredentialBroker`가 assumed creds에서 `BedrockTokenGenerator`로 발급해 `(role, region)`으로 캐시합니다.
@@ -128,7 +128,7 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 배포 단계별 상세 절차: [`deployment/docs/eks-fargate/`](deployment/docs/eks-fargate/) — 01 사전조건 ~ 07 Cognito 온보딩 + `troubleshooting.md`. 시크릿 계약: [`deployment/docs/secrets-contract.md`](deployment/docs/secrets-contract.md).
 
-> **현재 deliverable 의 배포 환경**: AWS 계정 `859741818597` (ap-northeast-2)
+> **현재 deliverable 의 배포 환경**: AWS 계정 `<MAIN-ACCOUNT-ID>` (ap-northeast-2)
 > 에 dev / prod 두 EKS Fargate 환경(둘 다 EKS 1.30) 운영. 구체 endpoint/Cognito
 > pool/ALB DNS 는 각 가이드의 **부록** 참조 — user-guide §B, admin-guide §D,
 > deployer-guide §E. claude-code(374)·cowork(905)는 cross-account, codex(859)는
@@ -185,7 +185,7 @@ Helm이 배포하는 워크로드는 6 Deployment + 1 Job이고, admin-chat-agen
 | `deployment/docs/` | 단계별 배포 절차(`eks-fargate/`) + 시크릿 계약(`secrets-contract.md`) |
 | `docs/` | 스펙(`admin-chat-agent-spec.md`)·아키텍처 drawio·클라이언트 연동 가이드(`guides/connect.md`, `guides/COWORK-GATEWAY-SETUP.md`) |
 | `guides/` | 최종 가이드 (배포자/어드민/사용자/QUICKSTART) — 부록에 현재 운영 환경 값 |
-| `_archive/` | 옛 자산(옛 계정 `374445650473` charts·terraform 포함) + 마이그레이션 로그. 빌드/배포 미참조 — history 보존용 |
+| `_archive/` | 옛 자산(옛 계정 `<CLAUDE-CODE-ACCOUNT-ID>` charts·terraform 포함) + 마이그레이션 로그. 빌드/배포 미참조 — history 보존용 |
 
 ---
 

--- a/projects/awsome-ai-gateway/README.md
+++ b/projects/awsome-ai-gateway/README.md
@@ -2,6 +2,8 @@
 
 > ⚠️ **This is a sample/prototype for demonstration purposes only. Not production-ready; review and harden before any production use.**
 
+[English README](README.en.md)
+
 > 사내 코딩 에이전트를 위한 통합 LLM 게이트웨이 (관리 콘솔 브랜드: **AWSome AI Gateway**)
 
 사내 코딩 에이전트(Claude Code / Codex / Cowork) 사용자를 위한 통합 LLM 게이트웨이. OIDC 인증 기반으로 Virtual Key를 자동 발급하고, 클라이언트별로 알맞은 백엔드(AWS Bedrock native / Bedrock Mantle)로 요청을 프록시합니다. 팀/사용자/앱(client)별 예산 관리, Rate Limit, 모델 접근 제어, 사용량 추적(ROI), 서버사이드 웹서치, 그리고 자연어로 운영 데이터를 질의하는 **AI BI 어시스턴트(admin-chat-agent)**를 제공합니다.
@@ -33,7 +35,7 @@
    claude-code               codex                          cowork
    Bedrock NATIVE            Bedrock Mantle                 Bedrock Mantle
    (boto3 invoke_model)      (OpenAI Responses API)         (Anthropic Messages)
-   계정 345678901234          계정 859 in-account             계정 234567890123
+   계정 374445650473          계정 859 in-account             계정 905418156477
    (ap-northeast-2)          (us-east-2, 오하이오)           (ap-northeast-1, 도쿄)
    STS AssumeRole(374 role)  assume 없음 — pod IRSA 직접      STS AssumeRole(905 role)
    ExternalId=claude-code-…  Mantle GPT-5.5                 ExternalId=cowork-…
@@ -63,12 +65,12 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 **멀티계정 정리**
 
-| 항목 | 계정 | region | 백엔드 | 방언 | cross-account |
+| 항목 | 계정 | region | 백엔드 | API 규격 | cross-account |
 |------|------|--------|--------|------|---------------|
-| 메인 배포 (게이트웨이 전 서비스 + Aurora + AgentCore Runtime/웹서치 GW + ECR) | `123456789012` | ap-northeast-2 | — | — | gateway-proxy IRSA 가 이 계정 |
-| claude-code | `345678901234` | ap-northeast-2 | Bedrock NATIVE (invoke_model) | Anthropic Messages | STS AssumeRole(ExternalId=`claude-code-bedrock`), 실패 시 859 in-account 투명 폴백 |
-| codex | `123456789012` (in-account) | us-east-2 | Bedrock Mantle GPT-5.5 | OpenAI Responses (`/v1/responses`) | 없음 — pod IRSA creds 직접 사용 |
-| cowork | `234567890123` | ap-northeast-1 | Bedrock Mantle Opus 4.8 | Anthropic Messages | STS AssumeRole(ExternalId=`cowork-bedrock`) |
+| 메인 배포 (게이트웨이 전 서비스 + Aurora + AgentCore Runtime/웹서치 GW + ECR) | `859741818597` | ap-northeast-2 | — | — | gateway-proxy IRSA 가 이 계정 |
+| claude-code | `374445650473` | ap-northeast-2 | Bedrock NATIVE (invoke_model) | Anthropic Messages | STS AssumeRole(ExternalId=`claude-code-bedrock`), 실패 시 859 in-account 투명 폴백 |
+| codex | `859741818597` (in-account) | us-east-2 | Bedrock Mantle GPT-5.5 | OpenAI Responses (`/v1/responses`) | 없음 — pod IRSA creds 직접 사용 |
+| cowork | `905418156477` | ap-northeast-1 | Bedrock Mantle Opus 4.8 | Anthropic Messages | STS AssumeRole(ExternalId=`cowork-bedrock`) |
 
 - cross-account는 `STS AssumeRole(DurationSeconds=3600)` + 선택적 `ExternalId`. claude-code(374 native)의 클라이언트는 `BedrockAccountClientProvider`가 `(role_arn, region, external_id)` 키로 vend/캐시합니다. assume 실패 시 게이트웨이는 859 in-account 클라이언트로 투명 폴백하므로 claude-code 요청은 죽지 않습니다.
 - codex/cowork Mantle bearer는 `MantleCredentialBroker`가 assumed creds에서 `BedrockTokenGenerator`로 발급해 `(role, region)`으로 캐시합니다.
@@ -92,11 +94,11 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 ## 주요 기능
 
-- **게이트웨이 코어** — OIDC→Virtual Key 자동 발급, 3-client(claude-code/codex/cowork) × 2-방언(Anthropic Messages / OpenAI Responses) 라우팅, 클라이언트별 백엔드 분기(Bedrock native / Mantle). 팀/사용자/앱(client)별 예산(HARD_BLOCK/SOFT_WARNING/THROTTLE), Rate Limit(USER/TEAM/GLOBAL 3-scope), 팀별 모델 접근 제어(allowed_models), 자동 다운그레이드(TEAM scope), 사용량/ROI 집계(`reasoning_tokens`·`web_search_count` 서브메트릭 포함).
+- **게이트웨이 코어** — OIDC→Virtual Key 자동 발급, 3-client(claude-code/codex/cowork) × 2-API 규격(Anthropic Messages / OpenAI Responses) 라우팅, 클라이언트별 백엔드 분기(Bedrock native / Mantle). 팀/사용자/앱(client)별 예산(HARD_BLOCK/SOFT_WARNING/THROTTLE), Rate Limit(USER/TEAM/GLOBAL 3-scope), 팀별 모델 접근 제어(allowed_models), 자동 다운그레이드(TEAM scope), 사용량/ROI 집계(`reasoning_tokens`·`web_search_count` 서브메트릭 포함).
 - **멀티앱 거버넌스 (Phase 2)** — 사용자별 모델 allow-list(팀 정책 override, migration 0014, admin-api `GET/PUT/DELETE /admin/users/{id}/allowed-models`), 사용자별 클라이언트 ACL(allowed-clients — 특정 사용자에게 claude-code/codex/cowork 중 일부만 허용), 앱(client)별 예산·Rate Limit 분리. 3-client가 각기 다른 계정·백엔드로 라우팅되는 데이터드리븐 프로파일(`routing_profiles`)이 이 거버넌스의 기반입니다.
 - **service-token** — 외부 시스템(비 OIDC)용 장수명 bearer 토큰 발급/회전. admin-api `POST/GET/DELETE /admin/service-tokens` + `/rotate`. 목록은 prefix만 노출하고 원문 토큰은 발급/회전 시 1회만 반환(migration 0015).
 - **Resilience** — readiness 게이트 `/health/ready`(열화/DB 풀 고갈 시 503, `/health`는 관대), 무효 VK 즉시 차단(무효키 폭주가 DB 커넥션 풀을 고갈시키지 못하도록 DB 세션을 안 엶), DB 풀 튜닝(`pool_timeout` 기본 10s fast-fail·`pool_recycle` 3600s·`pre_ping`), Redis 소켓 타임아웃/재시도 + rate-limit 회로 차단기, Redis 다운 시 in-memory rate-limit 근사 폴백, 응답 헤더 유출 방어(state에 값이 있을 때만 `X-*` 헤더 주입), 보안 이벤트 detector의 OrderedDict LRU(스푸핑된 IP churn OOM 방어), 비용 스트림 스풀링(Redis blip 시 XADD 실패 재발행).
-- **서버사이드 웹서치 (아키텍처 C)** — 게이트웨이가 `web_search` 툴을 주입하고 모델의 tool_use를 가로채 AgentCore Gateway 관리형 WebSearch(MCP over httpx, SigV4/IRSA)로 검색·재투입하는 서버사이드 방식. **클라이언트(Claude Code/Codex/Cowork) 무설정** — 그냥 질문하면 검색된 답이 옵니다. anthropic/responses 두 방언 지원, AgentCore 관리형 커넥터는 us-east-1 전용, 글로벌 kill-switch(`web_search_enabled`) 기본 off. 검색 횟수·토큰·비용을 per-client 추적. 상세: [`devlog_websearch.md`](devlog_websearch.md), E2E: [`e2e_report_websearch.md`](e2e_report_websearch.md).
+- **서버사이드 웹서치 (아키텍처 C)** — 게이트웨이가 `web_search` 툴을 주입하고 모델의 tool_use를 가로채 AgentCore Gateway 관리형 WebSearch(MCP over httpx, SigV4/IRSA)로 검색·재투입하는 서버사이드 방식. **클라이언트(Claude Code/Codex/Cowork) 무설정** — 그냥 질문하면 검색된 답이 옵니다. anthropic/responses 두 API 규격 지원, AgentCore 관리형 커넥터는 us-east-1 전용, 글로벌 kill-switch(`web_search_enabled`) 기본 off. 검색 횟수·토큰·비용을 per-client 추적. 상세: [`devlog_websearch.md`](devlog_websearch.md), E2E: [`e2e_report_websearch.md`](e2e_report_websearch.md).
 - **Admin UI (Next.js 14)** — 대시보드(KPI·비용 추이·모델 점유율 도넛·client 점유율 도넛·client 필터·팀/사용자 랭킹), 사용자/팀, 모델, 예산, Rate Limit, API Key, 실시간 모니터링, 분석(ROI), `/chat` BI 어시스턴트. 라이트/다크 Glass 디자인 + 기간 선택기. 대시보드 차트는 Chart.js, BI 차트는 recharts.
 - **AI BI 어시스턴트 (`/chat`)** — 자연어 질문 → 검증된 SQL 자동 생성(text2SQL) → Aurora 조회 → 마크다운 표 + recharts 차트로 답변. agents-as-tools 오케스트레이터(Orchestrator + SQL/Code/Validator/Viz/Report Specialist + L3 self-consistency)를 AWS Strands + Bedrock AgentCore Runtime으로 호스팅. deep 모드 및 L4 cross-family critic(옵션)도 존재. 실시간 토큰 스트리밍 + heartbeat.
 
@@ -109,7 +111,7 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 - **병목(claude-code, Bedrock native 한정)** — claude-code 경로는 boto3 동기 스트림을 async 이벤트루프에서 소비하려고 매 청크마다 `run_in_executor`로 스레드풀에 offload합니다. 청크 수신이 blocking이라 활성 SSE 하나가 스트림 수명 내내 스레드 슬롯 하나를 점유합니다. 대략적 동시성 산수(HPA 최대 30 pod × uvicorn `--workers 4` = 120 프로세스, 프로세스당 기본 스레드풀 ~6 → ~720 slot)로는 수천 동시 SSE에서 슬롯이 부족해질 수 있습니다. 스레드가 네트워크 대기 중이라 CPU가 한가해 CPU 기준 HPA(targetCPU 65%)가 스케일아웃하지 않는 사각지대가 있습니다.
 - **codex/cowork(Mantle)은 이 병목에서 자유** — Mantle 경로는 `httpx.AsyncClient` + `aiter_lines()`로 이미 완전 async라 스레드풀을 쓰지 않고 이벤트루프만으로 다수 스트림을 처리합니다.
 - **완화책(효과 큰 순)** — (1) 스트리밍 전용 ThreadPoolExecutor: `BEDROCK_STREAM_EXECUTOR_WORKERS` env가 `>0`이면 전용 executor, `0`/미설정이면 기본 공유 executor(무회귀·안전 롤백). **PoC로 코드에는 shipped됐으나 현재 어떤 chart values에도 배선돼 있지 않아 배포상 기본 비활성입니다.** (2) async httpx + 자체 SigV4로의 전환(정석) — 로컬 실측은 있으나 루프백·파싱0·소켓무제한 환경이라 실환경 미검증이며 착수 전 승인 게이트(골든 바이트캡처 테스트 + 실 Bedrock A/B 카나리) 통과가 조건. (3) uvicorn `--limit-concurrency` 백프레셔. (4) 커스텀 메트릭(활성 SSE/동시성 기준) HPA.
-- **관련 튜닝** — boto3 Bedrock 클라이언트 소켓 풀 하드캡 `max_pool_connections=50`(in-account/cross-account 동일, 대규모에는 상향 검토 대상), `bedrock_max_attempts=1`을 BotoConfig `retries`에 실제 배선(fallback 루프와의 재시도 폭풍 억제), uvicorn `--workers 4`는 Dockerfile CMD에 하드코딩(env override 불가).
+- **관련 튜닝** — boto3 Bedrock 클라이언트 소켓 풀 하드캡 `max_pool_connections=50`(in-account/cross-account 동일, 대규모에는 상향 검토 대상), `bedrock_max_attempts=1`을 BotoConfig `retries`에 실제 배선(fallback 루프와의 재시도 폭풍 억제), uvicorn `--workers ${WORKERS:-4}`는 shell-form CMD로 env override 가능(미설정 시 기본 4). Fargate 0.5 vCPU 환경에선 `WORKERS=2` 권장.
 
 > EKS Fargate에서 CPU 기반 HPA가 동작하려면 prometheus-adapter가 `metrics.k8s.io`를 서빙해야 합니다(표준 metrics-server는 kubelet authz 제약으로 미동작). 자세한 분석·완화 로드맵·승인 게이트는 [`devlog_websearch.md`](devlog_websearch.md) §부하 분석 참조.
 
@@ -126,7 +128,7 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 배포 단계별 상세 절차: [`deployment/docs/eks-fargate/`](deployment/docs/eks-fargate/) — 01 사전조건 ~ 07 Cognito 온보딩 + `troubleshooting.md`. 시크릿 계약: [`deployment/docs/secrets-contract.md`](deployment/docs/secrets-contract.md).
 
-> **현재 deliverable 의 배포 환경**: AWS 계정 `123456789012` (ap-northeast-2)
+> **현재 deliverable 의 배포 환경**: AWS 계정 `859741818597` (ap-northeast-2)
 > 에 dev / prod 두 EKS Fargate 환경(둘 다 EKS 1.30) 운영. 구체 endpoint/Cognito
 > pool/ALB DNS 는 각 가이드의 **부록** 참조 — user-guide §B, admin-guide §D,
 > deployer-guide §E. claude-code(374)·cowork(905)는 cross-account, codex(859)는
@@ -183,7 +185,7 @@ Helm이 배포하는 워크로드는 6 Deployment + 1 Job이고, admin-chat-agen
 | `deployment/docs/` | 단계별 배포 절차(`eks-fargate/`) + 시크릿 계약(`secrets-contract.md`) |
 | `docs/` | 스펙(`admin-chat-agent-spec.md`)·아키텍처 drawio·클라이언트 연동 가이드(`guides/connect.md`, `guides/COWORK-GATEWAY-SETUP.md`) |
 | `guides/` | 최종 가이드 (배포자/어드민/사용자/QUICKSTART) — 부록에 현재 운영 환경 값 |
-| `_archive/` | 옛 자산(옛 계정 `345678901234` charts·terraform 포함) + 마이그레이션 로그. 빌드/배포 미참조 — history 보존용 |
+| `_archive/` | 옛 자산(옛 계정 `374445650473` charts·terraform 포함) + 마이그레이션 로그. 빌드/배포 미참조 — history 보존용 |
 
 ---
 
@@ -258,6 +260,7 @@ LLM 의 환각·재계산을 막기 위한 **deterministic-tool-first** 설계. 
 - **tool 투명성** — orchestrator 의 도구 호출이 `tool_call`/`tool_result` 이벤트로
   스트리밍 → admin-ui 가 실행된 SQL·Python 코드·검증 결과를 그대로 렌더.
 
+---
 
 ## Original Builders
 
@@ -278,10 +281,10 @@ LLM 의 환각·재계산을 막기 위한 **deterministic-tool-first** 설계. 
 
 ---
 
-## License
-
-This sample code is made available under a modified MIT license (MIT-0). See the [LICENSE](../../LICENSE) file at the repository root.
+**Built with ❤️ by AWS Specialist SA Team and GenAIIC**
 
 ---
 
-**Built with ❤️ by AWS Specialist SA Team and GenAIIC**
+## License
+
+This sample code is made available under a modified MIT license (MIT-0). See the [LICENSE](LICENSE) file.


### PR DESCRIPTION
## Summary

- Add `README.en.md` — English version of the project README for international visitors
- Refine Korean `README.md`:
  - Replace "방언" (dialect) terminology with "API 규격" (API format) throughout
  - Update WORKERS section to reflect the env-override fix (shell-form CMD)
  - Add mutual language navigation links (ko ↔ en)
- English README includes a dedicated **Security Design** table for clearer visibility of the re-origination architecture

## Test plan

- [ ] Verify both README.md and README.en.md render correctly on GitHub
- [ ] Confirm cross-links between ko/en versions work
- [ ] No sensitive information added (account IDs unchanged from prior merge)