### PR TITLE
fix(awsome-ai-gateway): replace ambiguous account ID in test

### DIFF
--- a/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
+++ b/projects/awsome-ai-gateway/deployment/tui/tests/test_cli.py
@@ -76,8 +76,8 @@ def test_aws_account_id_none_when_cli_missing(monkeypatch):
 
 def test_llm_tfstate_defaults_includes_account_suffix():
     # 버킷은 S3 전역 유일성 때문에 계정 접미 필수, 락테이블은 접미 없음
-    bucket, table = cli.llm_tfstate_defaults("913524902871")
-    assert bucket == "llm-gateway-vanilla-tfstate-913524902871"
+    bucket, table = cli.llm_tfstate_defaults("123456789012")
+    assert bucket == "llm-gateway-vanilla-tfstate-123456789012"
     assert table == "llm-gateway-vanilla-tflock"
 
 


### PR DESCRIPTION
## Summary

Replace `913524902871` with `123456789012` (AWS documentation standard placeholder) in `deployment/tui/tests/test_cli.py`.

This number was not a real project account but could be mistaken for one. Per Japan team feedback via Charlie.

## Changes

- `test_cli.py:79-80` — account ID used in tfstate bucket name test → AWS doc placeholder

## Test plan

- [x] Verified no other occurrences of `913524902871` in the project
- [x] Test logic unchanged (just the example number)