### PR TITLE
fix+docs(awsome-ai-gateway): 12 bug fixes from production + competitive differentiation README

### DIFF
--- a/projects/awsome-ai-gateway/README.en.md
+++ b/projects/awsome-ai-gateway/README.en.md
@@ -66,6 +66,47 @@ Zero client-side configuration.
 
 ---
 
+## Advantages over Other Open-Source LLM Proxies
+
+### Security Architecture: Re-origination vs Relay
+
+Typical open-source LLM proxies **relay** client requests to upstream. Even with header manipulation or filtering, the fundamental approach is "pass through and selectively block" — a single configuration gap can leak credentials.
+
+AWSome AI Gateway uses **re-origination**. Inbound requests are deconstructed; only explicitly allowed fields are extracted; a new request is built from scratch with the gateway's own credentials (IRSA/SigV4/broker). Client keys (VK) never reach the upstream model. Upstream headers never reach the client. There is no configuration that weakens this boundary — security is structural.
+
+### Token Usage Accuracy
+
+| Aspect | Other Open-Source | AWSome AI Gateway |
+|--------|------------------|-------------------|
+| Primary accounting | Provider usage field (same) | Provider usage field (same) |
+| When usage field is incomplete/missing | Local tiktoken approximation (significant error on Claude models) | **Bedrock invocationMetrics** as billable ground truth + **Bedrock CountTokens API** for estimation → aligns with AWS billing |
+
+### Cost Preservation on Stream Interruption
+
+| Aspect | Other Open-Source | AWSome AI Gateway |
+|--------|------------------|-------------------|
+| When cost is recorded | Only on natural stream completion (all-or-nothing) | Text accumulated during stream + partial cost recorded on interruption |
+| Result of mid-stream disconnect | Tokens already consumed are recorded as **$0** (cost logic is skipped entirely) | Text up to the break point is measured via CountTokens API → **partial cost preserved** |
+
+→ "Inaccuracy" and "loss" are different problems. Other proxies may inaccurately record completed streams, but mid-stream interruptions record nothing at all. We handle both cases with precise Bedrock token counts.
+
+### Cost Recording Worker Fault Tolerance
+
+| Aspect | Other Open-Source | AWSome AI Gateway |
+|--------|------------------|-------------------|
+| Architecture | Single leader flushes to DB (Redis-lock-based leader election) | **Redis Stream Consumer Group** — leaderless, multiple workers consume in parallel |
+| On leader failure | Cost recording stalls for lock TTL duration (single point of failure) | Remaining pods continue consuming immediately (no single point of failure) |
+| Deadlock prevention | Redis lock blocks concurrent writes | Redis distributes messages without overlap — no locks needed |
+
+### Cascade Failure Prevention
+
+| Aspect | Other Open-Source | AWSome AI Gateway |
+|--------|------------------|-------------------|
+| Process structure | Request handling, billing, logging, scheduler in one monolithic event loop | Cost recording (cost-recorder-worker), notifications (notification-worker), scheduler run as **separate processes** |
+| Failure propagation | Billing flush delay directly stalls request processing | Worker failures do not affect the gateway core |
+
+---
+
 ## Key Features
 
 - **Gateway Core** — OIDC → Virtual Key auto-issuance, 3-client × 2 API formats (Anthropic Messages / OpenAI Responses) routing, per-client backend dispatch (Bedrock native / Mantle). Per-team/user/app budgets (HARD_BLOCK / SOFT_WARNING / THROTTLE), rate limits (USER / TEAM / GLOBAL scopes), model ACL, auto-downgrade, usage/ROI aggregation.

--- a/projects/awsome-ai-gateway/README.md
+++ b/projects/awsome-ai-gateway/README.md
@@ -92,6 +92,47 @@ WebSearch(MCP over httpx, SigV4/IRSA, us-east-1 전용) 호출 → 결과 재투
 
 ---
 
+## 타 오픈소스 LLM 프록시 대비 차별점
+
+### 보안 아키텍처: Re-origination vs Relay
+
+일반적인 오픈소스 LLM 프록시는 클라이언트 요청을 받아 업스트림에 **그대로 전달(relay)**합니다. 헤더 조작이나 필터링을 추가하더라도 본질적으로 "통과시키고 일부를 막는" 방식이라, 설정 누락 하나로 자격증명이 새어나가는 구조적 위험이 있습니다.
+
+AWSome AI Gateway는 **re-origination(요청 재구성 발신)** 방식입니다. 수신된 요청을 해체하고, 허용된 필드만 추출한 뒤, 게이트웨이 자체 자격증명(IRSA/SigV4/broker)으로 새 요청을 처음부터 만들어 보냅니다. 클라이언트 키(VK)는 업스트림에 절대 닿지 않고, 업스트림 헤더는 클라이언트에 절대 내려가지 않습니다. 이 경계를 약화시키는 설정 자체가 존재하지 않습니다 — 보안이 구조입니다.
+
+### 토큰 사용량 정확도
+
+| 관점 | 타 오픈소스 | AWSome AI Gateway |
+|------|------------|-------------------|
+| 기본 집계 | provider usage 필드 사용 (동일) | provider usage 필드 사용 (동일) |
+| usage 필드 불완전/부재 시 | 로컬 tiktoken 근사 (Claude 모델에서 오차 발생) | **Bedrock invocationMetrics** 를 billable 기준으로 채택 + 추정 필요 시 **Bedrock CountTokens API** 사용 → AWS billing 단위와 정합 |
+
+### 스트리밍 중단 시 비용 보존
+
+| 관점 | 타 오픈소스 | AWSome AI Gateway |
+|------|------------|-------------------|
+| 비용 기록 시점 | 스트림 자연 종료 시에만 실행 (all-or-nothing) | 스트리밍 중 텍스트 누적 + 중단 감지 시 부분 비용 기록 |
+| 중간 끊김 시 결과 | 이미 소비한 토큰 비용이 **0으로 기록** (계산 로직 자체를 건너뜀) | 끊긴 시점까지의 텍스트를 CountTokens API로 역산하여 **부분 비용 보존** |
+
+→ "근사(inaccuracy)"와 "누락(loss)"은 다른 문제입니다. 타 오픈소스는 완료된 스트림은 부정확하게라도 기록하지만, 중간 끊김은 아무것도 기록하지 않습니다. 우리는 완료든 중단이든 Bedrock 정밀 토큰 카운트로 처리합니다.
+
+### 비용 기록 워커 장애 대응
+
+| 관점 | 타 오픈소스 | AWSome AI Gateway |
+|------|------------|-------------------|
+| 아키텍처 | 리더 1명이 대표로 DB에 flush (Redis lock 기반 단일 리더) | **Redis Stream Consumer Group** — 리더 없이 여러 워커가 나눠 소비 |
+| 리더 장애 시 | 락 TTL만큼 비용 기록 정체 (단일 장애점) | 한 pod가 죽어도 나머지 pod가 즉시 소비 계속 (단일 장애점 없음) |
+| 데드락 방지 | Redis lock으로 동시 쓰기 차단 | Redis가 메시지를 겹치지 않게 자동 분배 — 락 불필요 |
+
+### Cascade 다운 방지
+
+| 관점 | 타 오픈소스 | AWSome AI Gateway |
+|------|------------|-------------------|
+| 프로세스 구조 | 요청 처리·비용·로깅·스케줄러가 monolithic event loop | 비용 기록(cost-recorder-worker), 알림(notification-worker), 스케줄러를 **별도 프로세스로 분리** |
+| 장애 전파 | 비용 flush 지연이 요청 처리 지연으로 직결 | 워커 장애가 gateway 본체에 영향 없음 |
+
+---
+
 ## 주요 기능
 
 - **게이트웨이 코어** — OIDC→Virtual Key 자동 발급, 3-client(claude-code/codex/cowork) × 2-API 규격(Anthropic Messages / OpenAI Responses) 라우팅, 클라이언트별 백엔드 분기(Bedrock native / Mantle). 팀/사용자/앱(client)별 예산(HARD_BLOCK/SOFT_WARNING/THROTTLE), Rate Limit(USER/TEAM/GLOBAL 3-scope), 팀별 모델 접근 제어(allowed_models), 자동 다운그레이드(TEAM scope), 사용량/ROI 집계(`reasoning_tokens`·`web_search_count` 서브메트릭 포함).

--- a/projects/awsome-ai-gateway/admin-api/src/app/repositories/user_repository.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/repositories/user_repository.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import func, select
+from sqlalchemy import String, all_, any_, bindparam, func, select, update
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import lazyload, selectinload
 
 from app.models.auth import Department, Organization, Team, User, UserRole
 
@@ -19,6 +20,14 @@ class UserRepository:
 
     async def get_default_org(self) -> Organization | None:
         stmt = select(Organization).limit(1)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_first_org_id(self) -> uuid.UUID | None:
+        """org id 만 단건 조회(멤버·부서 그래프 미로드). sync_all 의 팀 캐시가
+        신규 부서 생성 시 사용할 org 를 1회 확보하기 위한 경량 경로 —
+        ``list_all_orgs`` (부서→팀→멤버 전량 selectinload) 의 OOM 을 회피한다."""
+        stmt = select(Organization.id).order_by(Organization.name).limit(1)
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
@@ -101,6 +110,12 @@ class UserRepository:
         await self._session.flush()
         return user
 
+    async def flush(self) -> None:
+        """Flush pending ORM changes so a failing write surfaces here (e.g. a
+        UNIQUE email collision) instead of being deferred to a later commit /
+        savepoint release. Lets callers count/act only after a successful flush."""
+        await self._session.flush()
+
     async def update_user_team(self, user_id: uuid.UUID, team_id: uuid.UUID) -> User | None:
         user = await self.get_user(user_id)
         if user is None:
@@ -139,6 +154,93 @@ class UserRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().unique().all())
+
+    async def list_teams_lite(self) -> list[Team]:
+        """멤버 미포함 경량 팀 조회. sync_all 의 팀 캐시 구축용 —
+        list_all_teams(members selectinload)의 반복 호출로 인한 메모리 폭발을 회피.
+
+        Team.members/department 는 모델 레벨에서 ``lazy="selectin"`` 이므로,
+        ``lazyload`` 로 명시적으로 override 하지 않으면 plain select 여도 여전히
+        멤버 그래프를 eager-load 한다. (id, dept_id, name 컬럼만 필요.)"""
+        stmt = (
+            select(Team)
+            .options(lazyload(Team.members), lazyload(Team.department))
+            .order_by(Team.name)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_departments_lite(self) -> list[Department]:
+        """멤버·팀 미포함 경량 부서 조회. sync_all 의 부서 캐시 구축용.
+
+        Department.teams/organization 도 ``lazy="selectin"`` 기본값이라 lazyload
+        override 로 eager-load 를 차단한다. (id, name 컬럼만 필요.)"""
+        stmt = (
+            select(Department)
+            .options(lazyload(Department.teams), lazyload(Department.organization))
+            .order_by(Department.name)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def prefetch_users_by_subjects(self, subs: set[str]) -> dict[str, dict]:
+        """sso_subject 집합에 해당하는 기존 유저의 스칼라 스냅샷을 일괄 조회.
+
+        sync_all 의 유저당 get_by_sso_subject(N+1) 를 1~수 회 배열-바인딩 조회로
+        대체한다. ORM 엔티티를 만들지 않고 필요한 컬럼만 SELECT 하여 gate 판정용
+        dict 를 반환한다({sso_subject: {id,email,display_name,team_id,role,is_active}}).
+        subs 가 크면(수만) 청크로 나눠 조회한다(과대 배열 파라미터 회피).
+
+        포함 매칭이므로 `= ANY(:subs::VARCHAR[])` 를 쓴다(deactivate 의 `!= ALL`
+        none-of 와 반대). 배열 단일 파라미터라 요소당 스칼라 바인드 폭발이 없다.
+        """
+        result: dict[str, dict] = {}
+        if not subs:
+            return result
+        subs_list = list(subs)
+        CHUNK = 5000
+        for i in range(0, len(subs_list), CHUNK):
+            chunk = subs_list[i : i + CHUNK]
+            stmt = select(
+                User.sso_subject, User.id, User.email, User.display_name,
+                User.team_id, User.role, User.is_active,
+            ).where(
+                User.sso_subject == any_(
+                    bindparam("subs", value=chunk, type_=ARRAY(String))
+                )
+            )
+            rows = await self._session.execute(stmt)
+            for r in rows:
+                result[r.sso_subject] = {
+                    "id": r.id, "email": r.email, "display_name": r.display_name,
+                    "team_id": r.team_id, "role": r.role, "is_active": r.is_active,
+                }
+        return result
+
+    async def deactivate_missing_oidc_users(
+        self, seen_subjects: set[str], provider: str
+    ) -> int:
+        """provider 유저 중 seen_subjects 에 없고 현재 활성인 유저를 bulk 비활성화.
+
+        sync_all reconcile 전용. ORM 객체를 로드하지 않고 단일 UPDATE 로 처리해
+        1만+ 유저 로드 시의 메모리 폭발을 회피한다. 변경 행 수를 반환한다.
+        """
+        if seen_subjects:
+            subject_filter = User.sso_subject != all_(
+                bindparam("seen", value=list(seen_subjects), type_=ARRAY(String))
+            )
+        else:
+            subject_filter = User.sso_subject.isnot(None)
+        stmt = (
+            update(User)
+            .where(User.provider == provider)
+            .where(User.is_active.is_(True))
+            .where(subject_filter)
+            .values(is_active=False)
+            .execution_options(synchronize_session=False)
+        )
+        result = await self._session.execute(stmt)
+        return result.rowcount or 0
 
     async def list_users(
         self,

--- a/projects/awsome-ai-gateway/admin-api/src/app/services/budget_service.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/services/budget_service.py
@@ -160,6 +160,25 @@ class BudgetService:
                 except Exception:
                     logger.warning("seed_spent.redis_set_failed", key=redis_key)
 
+                # Per-app seed must also refresh the total key (client=None) so
+                # enforcement sees the correct aggregate.
+                if client is not None and scope == "USER":
+                    from sqlalchemy import text as sa_text
+                    total_row = await session.execute(
+                        sa_text(
+                            "SELECT COALESCE(SUM(used_usd), 0) "
+                            "FROM budget.budget_usages "
+                            "WHERE scope = 'USER' AND scope_id = :sid AND period = :period"
+                        ),
+                        {"sid": str(sid), "period": item.period},
+                    )
+                    total_val = total_row.scalar() or 0
+                    total_key = _redis_usage_key(scope, str(sid), item.period, None)
+                    try:
+                        await self._cache_mgr._redis.set(total_key, str(total_val))
+                    except Exception:
+                        logger.warning("seed_spent.redis_total_refresh_failed", key=total_key)
+
                 res.after_usd = item.spent_usd
 
                 await audit_logger.log(

--- a/projects/awsome-ai-gateway/admin-api/src/app/services/cognito_sync_service.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/services/cognito_sync_service.py
@@ -25,6 +25,23 @@ from app.repositories.user_repository import UserRepository
 
 logger = structlog.get_logger()
 
+BATCH_SIZE = 500  # 유저 upsert 배치 commit 단위. 초과 시 commit + expunge_all 로
+                  # identity map 을 비워 sync_all 메모리 상한을 확보한다.
+
+
+def _needs_update(
+    snap: dict, *, email: str, name: str, team_id, role, enabled: bool
+) -> bool:
+    """prefetch gate 판정. _upsert_one_user 의 update 분기와 1:1 동일 조건이어야 한다.
+    (email 이 truthy 이고 다르면) OR display_name/team_id/role/is_active 변경."""
+    return (
+        (bool(email) and snap["email"] != email)
+        or snap["display_name"] != name
+        or snap["team_id"] != team_id
+        or snap["role"] != role
+        or snap["is_active"] != enabled
+    )
+
 
 @dataclass
 class SyncResult:
@@ -37,6 +54,16 @@ class SyncResult:
     # 단일 사용자 sync 대상 유저의 DB id(str). 후속 처리(개인별 allowed_clients/
     # allowed_models)용. Cognito·DB 모두 없는 no-op 이면 None.
     user_id: str | None = None
+
+
+@dataclass
+class _TeamCache:
+    """sync_all 진입 시 1회 구축하는 팀/부서 인덱스. expunge 후에도 안전하도록
+    ORM 객체가 아니라 PK(uuid)만 보유한다."""
+    teams: dict[tuple[uuid.UUID, str], uuid.UUID] = field(default_factory=dict)
+    depts_by_name: dict[str, uuid.UUID] = field(default_factory=dict)
+    default_dept_id: uuid.UUID | None = None
+    org_id: uuid.UUID | None = None
 
 
 class CognitoSyncService:
@@ -66,36 +93,36 @@ class CognitoSyncService:
 
         repo = UserRepository(session)
 
-        # 1. Cognito 그룹 목록 가져오기
+        # 0. 팀/부서 캐시 1회 구축 (멤버 미포함 경량 조회) — 그룹마다 전체 그래프를
+        #    반복 로드하던 것을 대체(OOM 주원인 제거).
+        cache = await self._build_team_cache(repo)
+
+        # 1. Cognito 그룹 목록
         try:
-            groups = await asyncio.to_thread(
-                self._list_all_groups, user_pool_id
-            )
+            groups = await asyncio.to_thread(self._list_all_groups, user_pool_id)
         except Exception as e:
             result.errors.append(f"Failed to list groups: {e}")
             return result
 
-        # 2. 그룹별 멤버 수집 → user_sub 별 소속 그룹 + 프로필 정보 축적
-        #    user_sub → { "email", "name", "enabled", "groups": [group_name, ...] }
+        # 2. 그룹별 멤버 수집 → user_sub 별 프로필/그룹 축적
         user_map: dict[str, dict] = {}
-        # group_name → Team (팀 매핑 가능한 그룹만)
-        team_map: dict[str, Team] = {}
+        # group_name → team_id (팀 매핑 가능한 그룹만)
+        group_team_id: dict[str, uuid.UUID] = {}
 
         for group in groups:
             group_name = group["GroupName"]
-
-            # 팀 매핑 가능한 그룹이면 부서/팀 확보
             parsed = self._parse_group(group_name)
             if parsed is not None:
                 dept_name, team_name = parsed
                 result.groups_synced += 1
                 try:
-                    team = await self._ensure_team(repo, session, dept_name, team_name)
-                    team_map[group_name] = team
+                    tid = await self._ensure_team_id(
+                        repo, session, cache, dept_name, team_name
+                    )
+                    group_team_id[group_name] = tid
                 except Exception as e:
                     result.errors.append(f"Failed to ensure team {team_name}: {e}")
 
-            # 그룹 멤버 가져오기 (admin 그룹 포함 — role 결정에 필요)
             try:
                 members = await asyncio.to_thread(
                     self._list_users_in_group, user_pool_id, group_name
@@ -117,13 +144,12 @@ class CognitoSyncService:
                     }
                 user_map[sub]["groups"].append(group_name)
 
-        # 2b. 전체 유저 목록으로 user_map 보완 (그룹 삭제 시 누락 방지)
+        # 2b. 전체 유저 목록으로 보완 (그룹 삭제 시 누락 방지)
         try:
             all_cognito_users = await asyncio.to_thread(
                 self._list_all_users, user_pool_id
             )
             for cu in all_cognito_users:
-                # sub은 Attributes에 있거나 Username 자체가 sub인 경우도 있음
                 sub = self._get_attr(cu, "sub") or cu.get("Username")
                 if not sub:
                     continue
@@ -137,8 +163,13 @@ class CognitoSyncService:
         except Exception as e:
             result.errors.append(f"Failed to list all users: {e}")
 
-        # 3. 사용자별 DB upsert
+        # 3. 사용자별 DB upsert (배치 commit + expunge 로 메모리 상한)
+        # 유저 upsert 전 기존 유저 스냅샷 일괄 prefetch (per-user 조회 N+1 제거).
+        existing_snaps = await repo.prefetch_users_by_subjects(set(user_map.keys()))
+
         seen_sso_subjects: set[str] = set()
+        default_team_id = uuid.UUID(settings.DEFAULT_TEAM_ID)
+        processed = 0
 
         for sub, info in user_map.items():
             email = info["email"]
@@ -146,102 +177,62 @@ class CognitoSyncService:
             enabled = info["enabled"]
             user_groups: list[str] = info["groups"]
 
-            # 팀 결정: 사용자가 속한 그룹 중 첫 번째 팀 매핑 가능한 그룹
             team_id: uuid.UUID | None = None
             for g in user_groups:
-                if g in team_map:
-                    team_id = team_map[g].id
+                if g in group_team_id:
+                    team_id = group_team_id[g]
                     break
-
             if team_id is None:
-                # 팀 매핑 불가 (admin-only 그룹 등) → DEFAULT_TEAM_ID
-                team_id = uuid.UUID(settings.DEFAULT_TEAM_ID)
+                team_id = default_team_id
 
+            # skip 여부와 무관하게 항상 seen 에 추가 — reconcile(4단계)이 skip 된
+            # 유저를 잘못 비활성화하지 않도록 (불변식).
             seen_sso_subjects.add(sub)
-
-            # Role 결정 (사용자의 실제 그룹 기반)
             role = self._derive_role(email, user_groups)
 
-            # DB upsert
+            # gate: 확실히 안 바뀐 기존 유저는 upsert 를 건너뜀 (DB 왕복 0).
+            # snap None(신규/재생성 새 sub)은 절대 skip 하지 않는다 — email reconcile
+            # 규약(_upsert_one_user 내부)이 보존돼야 하므로 항상 upsert 경로로.
+            snap = existing_snaps.get(sub)
+            if snap is not None and not _needs_update(
+                snap, email=email, name=name, team_id=team_id, role=role, enabled=enabled
+            ):
+                continue
+
             try:
-                # 1차: sso_subject 로 조회.
-                existing = await repo.get_by_sso_subject(sub)
-
-                # 2차 fallback: email 로 재조회. Cognito 유저 삭제·재생성 시 username
-                # (email)은 같아도 새 sub(UUID)가 발급되어 1차 조회가 miss 한다. 이때
-                # 같은 email 의 기존 row 를 재사용 + sso_subject 를 새 sub 로 갱신하면
-                # 새 sub INSERT → email UNIQUE 충돌(IntegrityError 누적, row 미갱신)을
-                # 원천 차단한다. oidc_service._upsert_user 와 동일 규약.
-                if existing is None:
-                    by_email = await repo.get_by_email(email)
-                    if by_email is not None:
-                        logger.info(
-                            "cognito_sync.sso_subject_reconciled",
-                            user_id=str(by_email.id),
-                            email=email,
-                            old_sso_subject=by_email.sso_subject,
-                            new_sso_subject=sub,
-                        )
-                        by_email.sso_subject = sub
-                        existing = by_email
-                        result.users_updated += 1
-
-                if existing is None:
-                    user = User(
-                        id=uuid.uuid4(),
-                        email=email,
-                        display_name=name,
-                        role=role,
-                        sso_subject=sub,
-                        team_id=team_id,
-                        is_active=enabled,
-                        provider=settings.OIDC_PROVIDER_NAME,
+                # SAVEPOINT 로 각 유저 upsert 를 격리. flush 실패(예: email UNIQUE
+                # 충돌)가 발생해도 savepoint 만 롤백되고 외부 트랜잭션은 건강하게
+                # 유지된다 → 이후 배치/잔여 commit + reconcile/stale-team 이 정상 수행.
+                async with session.begin_nested():
+                    await self._upsert_one_user(
+                        repo, sub=sub, email=email, name=name, enabled=enabled,
+                        team_id=team_id, role=role, result=result,
                     )
-                    await repo.create_user(user)
-                    result.users_created += 1
-                else:
-                    changed = False
-                    if existing.email != email:
-                        existing.email = email
-                        changed = True
-                    if existing.display_name != name:
-                        existing.display_name = name
-                        changed = True
-                    if existing.team_id != team_id:
-                        existing.team_id = team_id
-                        changed = True
-                    if existing.role != role:
-                        existing.role = role
-                        changed = True
-                    if existing.is_active != enabled:
-                        existing.is_active = enabled
-                        changed = True
-                    if changed:
-                        result.users_updated += 1
             except Exception as e:
                 result.errors.append(f"Failed to sync user {email}: {e}")
 
-        # 4. Cognito 에 없는 OIDC 사용자 비활성화
+            processed += 1
+            if processed % BATCH_SIZE == 0:
+                await session.commit()
+                session.expunge_all()
+
+        # 잔여분 commit
+        await session.commit()
+
+        # 4. Cognito 에 없는 OIDC 사용자 비활성화 — bulk UPDATE (ORM 전량 로드 제거).
+        #    반드시 전체 upsert 완료 후. seen 에 없는 유저만 비활성화.
         if settings.COGNITO_SYNC_DEACTIVATE_MISSING:
             try:
-                all_users = await repo.list_users(limit=10000)
-                for user in all_users:
-                    if (
-                        user.provider == settings.OIDC_PROVIDER_NAME
-                        and user.sso_subject not in seen_sso_subjects
-                        and user.is_active
-                    ):
-                        user.is_active = False
-                        result.users_deactivated += 1
+                deactivated = await repo.deactivate_missing_oidc_users(
+                    seen_sso_subjects, settings.OIDC_PROVIDER_NAME
+                )
+                result.users_deactivated += deactivated
+                await session.commit()
             except Exception as e:
                 result.errors.append(f"Failed to deactivate missing users: {e}")
 
-        # 5. Cognito 에 없는 팀 정리
-        # team_map에 있는 팀 = Cognito 그룹에서 매핑된 팀
-        # DB의 팀 중 team_map에 없고 Default Team이 아닌 팀 → 멤버를 Default Team으로 이동
-        # 팀 자체는 삭제하지 않음 (usage_logs FK 제약)
-        default_team_id = uuid.UUID(settings.DEFAULT_TEAM_ID)
-        synced_team_ids = {t.id for t in team_map.values()}
+        # 5. Cognito 에 없는 팀 정리 — 멤버 이동을 위해 members 포함 조회 유지.
+        synced_team_ids = set(group_team_id.values())
         try:
             all_teams = await repo.list_all_teams()
             for team in all_teams:
@@ -249,7 +240,6 @@ class CognitoSyncService:
                     continue
                 if team.id in synced_team_ids:
                     continue
-                # 팀 멤버를 Default Team으로 이동
                 moved = [m for m in (team.members or []) if m.is_active]
                 for member in moved:
                     member.team_id = default_team_id
@@ -286,6 +276,12 @@ class CognitoSyncService:
 
         upsert 된(생성/갱신) User 를 반환한다 — sync_user 가 응답 user_id 확보용."""
         settings = get_settings()
+        # Track whether this call mutated an existing row. We flush ONCE at the
+        # end and only then increment users_updated — so a deferred flush failure
+        # (e.g. an email UNIQUE collision that the enclosing SAVEPOINT will roll
+        # back) surfaces here and the counter is NOT bumped for a change that did
+        # not persist.
+        updated = False
         existing = await repo.get_by_sso_subject(sub)
         if existing is None and email:
             by_email = await repo.get_by_email(email)
@@ -297,7 +293,7 @@ class CognitoSyncService:
                 )
                 by_email.sso_subject = sub
                 existing = by_email
-                result.users_updated += 1
+                updated = True
         if existing is None:
             new_user = User(
                 id=uuid.uuid4(), email=email, display_name=name, role=role,
@@ -308,18 +304,27 @@ class CognitoSyncService:
             result.users_created += 1
             return new_user
         else:
-            changed = False
             if email and existing.email != email:
-                existing.email = email; changed = True
+                existing.email = email
+                updated = True
             if existing.display_name != name:
-                existing.display_name = name; changed = True
+                existing.display_name = name
+                updated = True
             if existing.team_id != team_id:
-                existing.team_id = team_id; changed = True
+                existing.team_id = team_id
+                updated = True
             if existing.role != role:
-                existing.role = role; changed = True
+                existing.role = role
+                updated = True
             if existing.is_active != enabled:
-                existing.is_active = enabled; changed = True
-            if changed:
+                existing.is_active = enabled
+                updated = True
+            if updated:
+                # Flush pending mutations so a failure (e.g. UNIQUE email
+                # collision) raises HERE, before we count. If it raises, the
+                # exception propagates to the caller's try/except (recorded in
+                # result.errors) and users_updated stays untouched.
+                await repo.flush()
                 result.users_updated += 1
             return existing
 
@@ -633,6 +638,58 @@ class CognitoSyncService:
         team = Team(id=uuid.uuid4(), dept_id=dept.id, name=team_name)
         await repo.create_team(team)
         return team
+
+    async def _build_team_cache(self, repo: UserRepository) -> _TeamCache:
+        """멤버 미포함 경량 조회로 팀/부서 인덱스를 1회 구축.
+
+        sync_all 이 그룹마다 list_all_orgs/list_all_teams(members selectinload)를
+        반복 호출하던 것을 대체한다 — OOM 의 주원인."""
+        settings = get_settings()
+        cache = _TeamCache()
+        for d in await repo.list_departments_lite():
+            cache.depts_by_name[d.name] = d.id
+        for t in await repo.list_teams_lite():
+            cache.teams[(t.dept_id, t.name)] = t.id
+        # 신규 부서 생성 시 배치할 org id 를 1회 확보(멤버 그래프 미로드).
+        cache.org_id = await repo.get_first_org_id()
+        try:
+            cache.default_dept_id = uuid.UUID(settings.DEFAULT_DEPT_ID)
+        except (ValueError, TypeError):
+            cache.default_dept_id = None
+        return cache
+
+    async def _ensure_team_id(
+        self, repo: UserRepository, session, cache: _TeamCache,
+        dept_name: str | None, team_name: str,
+    ) -> uuid.UUID:
+        """캐시 기반 팀 확보. 없으면 부서·팀을 생성하고 캐시에 즉시 반영한 뒤
+        team_id(uuid)를 반환한다. ORM 객체를 반환하지 않아 expunge 후에도 안전."""
+        settings = get_settings()
+
+        # 부서 id 결정
+        if dept_name is None:
+            dept_id = cache.default_dept_id or uuid.UUID(settings.DEFAULT_DEPT_ID)
+        else:
+            dept_id = cache.depts_by_name.get(dept_name)
+            if dept_id is None:
+                if cache.org_id is None:
+                    raise ValueError(f"Cannot resolve department for {dept_name}")
+                new_dept = Department(
+                    id=uuid.uuid4(), org_id=cache.org_id, name=dept_name
+                )
+                await repo.create_department(new_dept)
+                dept_id = new_dept.id
+                cache.depts_by_name[dept_name] = dept_id
+
+        key = (dept_id, team_name)
+        cached = cache.teams.get(key)
+        if cached is not None:
+            return cached
+
+        team = Team(id=uuid.uuid4(), dept_id=dept_id, name=team_name)
+        await repo.create_team(team)
+        cache.teams[key] = team.id
+        return team.id
 
     @staticmethod
     def _derive_role(email: str, user_groups: list[str]) -> UserRole:

--- a/projects/awsome-ai-gateway/admin-ui/src/app/page.tsx
+++ b/projects/awsome-ai-gateway/admin-ui/src/app/page.tsx
@@ -126,7 +126,7 @@ async function DashboardKPIs({ period, client }: { period: string; client: strin
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           <KPICard
             title="이번 달 사용량"
-            value={fmtUsd2(totalUsageUsd)}
+            value={fmtUsd2(summary.total_cost_usd ?? totalUsageUsd)}
             icon={<DollarSign size={18} aria-hidden="true" />}
             description="USD 기준 당월 누적 비용"
           />

--- a/projects/awsome-ai-gateway/db/init/03_seed_data.sql
+++ b/projects/awsome-ai-gateway/db/init/03_seed_data.sql
@@ -39,6 +39,19 @@ INSERT INTO auth.users (id, team_id, email, display_name, role, sso_subject) VAL
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================
+-- Service-Token Synthetic User (FK target for service_tokens.created_by)
+-- ============================================================
+
+INSERT INTO auth.users (id, team_id, email, display_name, role, sso_subject) VALUES
+    ('00000000-0000-4000-a000-000000000011',
+     '00000000-0000-4000-a000-000000000003',
+     'service-token@system.internal',
+     'Service Token System',
+     'ADMIN',
+     'service-token-system')
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
 -- Default Rotation Policy (GLOBAL, 90 days)
 -- ============================================================
 

--- a/projects/awsome-ai-gateway/docker-compose.yml
+++ b/projects/awsome-ai-gateway/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       admin-api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       start_period: 60s

--- a/projects/awsome-ai-gateway/gateway-cli/src/statusline/formatter.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/statusline/formatter.py
@@ -11,12 +11,17 @@ from typing import Optional
 
 from statusline.usage_client import UsageInfo
 
-# Model alias → short display name
-_MODEL_SHORT = {
-    "claude-opus-4-6": "Opus",
-    "claude-sonnet-4-6": "Sonnet",
-    "claude-haiku-4-5": "Haiku",
-}
+def _short_name(alias: str) -> str:
+    """Model alias → short display name (substring match for any format)."""
+    a = alias.lower()
+    if "opus" in a:
+        return "Opus"
+    if "sonnet" in a:
+        return "Sonnet"
+    if "haiku" in a:
+        return "Haiku"
+    parts = alias.rsplit("-", 1)
+    return parts[-1].capitalize() if len(parts) > 1 else alias
 
 
 class Severity(str, Enum):
@@ -106,7 +111,7 @@ def format_status(state: StatuslineState) -> str:
 
     parts = [header]
     for m in sorted_models:
-        short = _MODEL_SHORT.get(m.model, m.model.split(".")[-1])
+        short = _short_name(m.model)
         mc = _MODEL_COLOR.get(short, _WHITE)
 
         tokens = []

--- a/projects/awsome-ai-gateway/gateway-cli/src/statusline/usage_client.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/statusline/usage_client.py
@@ -44,7 +44,10 @@ def fetch_usage(config: StatuslineConfig, virtual_key: str) -> UsageInfo:
 
     resp = requests.get(
         url,
-        headers={"Authorization": f"Bearer {virtual_key}"},
+        headers={
+            "Authorization": f"Bearer {virtual_key}",
+            "User-Agent": "claude-cli/gateway-cli-statusline",
+        },
         timeout=(config.connect_timeout, config.read_timeout),
     )
     resp.raise_for_status()

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/providers/bedrock_adapter.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/providers/bedrock_adapter.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import structlog
@@ -11,6 +13,9 @@ from botocore.exceptions import ClientError
 
 from app.providers.base import ProviderAdapter
 from app.schemas.domain import TokenUsage
+
+_BEDROCK_POOL_SIZE = int(os.environ.get("BEDROCK_THREAD_POOL_SIZE", "128"))
+_bedrock_executor = ThreadPoolExecutor(max_workers=_BEDROCK_POOL_SIZE, thread_name_prefix="bedrock")
 
 logger = structlog.get_logger(__name__)
 
@@ -79,7 +84,7 @@ class BedrockAdapter(ProviderAdapter):
             client = await self._get_client()
             if path_suffix in ("invoke", ""):
                 response = await loop.run_in_executor(
-                    None,
+                    _bedrock_executor,
                     lambda: client.invoke_model(
                         modelId=model_id,
                         body=request_body,
@@ -98,7 +103,7 @@ class BedrockAdapter(ProviderAdapter):
             elif path_suffix == "converse":
                 parsed_req = json.loads(request_body)
                 response = await loop.run_in_executor(
-                    None,
+                    _bedrock_executor,
                     lambda: client.converse(
                         modelId=model_id,
                         **{k: v for k, v in parsed_req.items() if k != "modelId"},
@@ -167,7 +172,7 @@ class BedrockAdapter(ProviderAdapter):
             client = await self._get_client()
             if path_suffix == "invoke-with-response-stream":
                 response = await loop.run_in_executor(
-                    None,
+                    _bedrock_executor,
                     lambda: client.invoke_model_with_response_stream(
                         modelId=model_id,
                         body=request_body,
@@ -187,7 +192,7 @@ class BedrockAdapter(ProviderAdapter):
             elif path_suffix == "converse-stream":
                 parsed_req = json.loads(request_body)
                 response = await loop.run_in_executor(
-                    None,
+                    _bedrock_executor,
                     lambda: client.converse_stream(
                         modelId=model_id,
                         **{k: v for k, v in parsed_req.items() if k != "modelId"},
@@ -251,7 +256,7 @@ class BedrockAdapter(ProviderAdapter):
                 return sentinel
 
         while True:
-            event = await loop.run_in_executor(None, _next)
+            event = await loop.run_in_executor(_bedrock_executor, _next)
             if event is sentinel:
                 return
             chunk = event.get("chunk", {})
@@ -272,7 +277,7 @@ class BedrockAdapter(ProviderAdapter):
                 return sentinel
 
         while True:
-            event = await loop.run_in_executor(None, _next)
+            event = await loop.run_in_executor(_bedrock_executor, _next)
             if event is sentinel:
                 return
             yield json.dumps(event).encode()

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/bedrock.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/bedrock.py
@@ -138,12 +138,11 @@ async def _handle_bedrock(request: Request, model_id: str, path_suffix: str, str
             _router_service.check_key_scope(auth_context, model_config)
         except PermissionError:
             return JSONResponse(
-                status_code=403,
+                status_code=400,
                 content={
                     "error": {
-                        "type": "authentication_error",
-                        "message": "Model not allowed",
-                        "code": "model_not_allowed",
+                        "type": "invalid_request_error",
+                        "message": f"Your account does not have access to model '{model_config.alias}'. Contact your administrator to request access.",
                     }
                 },
             )

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/messages.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/messages.py
@@ -631,11 +631,11 @@ async def count_tokens(request: Request) -> JSONResponse:
             _router_service.check_key_scope(auth_context, model_config)
         except PermissionError:
             return JSONResponse(
-                status_code=403,
+                status_code=400,
                 content={
                     "error": {
-                        "type": "permission_error",
-                        "message": "Model not allowed for this key",
+                        "type": "invalid_request_error",
+                        "message": f"Your account does not have access to model '{model_config.alias}'. Contact your administrator to request access.",
                     }
                 },
             )

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/openai_compat.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/openai_compat.py
@@ -185,12 +185,11 @@ async def _handle_openai(request: Request, path: str):
             _router_service.check_key_scope(auth_context, model_config)
         except PermissionError:
             return JSONResponse(
-                status_code=403,
+                status_code=400,
                 content={
                     "error": {
-                        "type": "authentication_error",
-                        "message": "Model not allowed",
-                        "code": "model_not_allowed",
+                        "type": "invalid_request_error",
+                        "message": f"Your account does not have access to model '{model_config.alias}'. Contact your administrator to request access.",
                     }
                 },
             )
@@ -369,9 +368,9 @@ async def _handle_responses(request: Request):
             _router_service.check_key_scope(auth_context, model_config)
         except PermissionError:
             return JSONResponse(
-                status_code=403,
-                content={"error": {"type": "authentication_error",
-                                    "message": "Model not allowed", "code": "model_not_allowed"}},
+                status_code=400,
+                content={"error": {"type": "invalid_request_error",
+                                    "message": f"Your account does not have access to model '{model_config.alias}'. Contact your administrator to request access."}},
             )
 
     # Pre-reserve RPM + TPM (USER/TEAM/GLOBAL) — same enforcement as chat path.

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/services/fallback_loop.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/services/fallback_loop.py
@@ -178,13 +178,13 @@ async def run_fallback_loop(
                 # on a fallback candidate just skip (the original 403 was what mattered).
                 if is_original:
                     return FallbackResult(
-                        status=403,
+                        status=400,
                         payload=(
                             json.dumps(
                                 {
                                     "error": {
-                                        "type": "permission_error",
-                                        "message": "Model not allowed for this key",
+                                        "type": "invalid_request_error",
+                                        "message": f"Your account does not have access to model '{candidate_config.alias}'. Contact your administrator to request access.",
                                     }
                                 }
                             ).encode(),

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/regression/test_bedrock_thread_pool.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/regression/test_bedrock_thread_pool.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Amazon.com
+"""Regression: Bedrock adapter uses dedicated ThreadPool (not default None executor)."""
+import pytest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+@pytest.mark.unit
+def test_bedrock_executor_defined():
+    src = (SRC / "app/providers/bedrock_adapter.py").read_text()
+    assert "ThreadPoolExecutor" in src
+    assert "_bedrock_executor" in src
+
+
+@pytest.mark.unit
+def test_no_none_executor_in_bedrock():
+    src = (SRC / "app/providers/bedrock_adapter.py").read_text()
+    assert "run_in_executor(None," not in src, "Bedrock adapter still uses default executor (None)"
+
+
+@pytest.mark.unit
+def test_pool_size_configurable():
+    src = (SRC / "app/providers/bedrock_adapter.py").read_text()
+    assert "BEDROCK_THREAD_POOL_SIZE" in src
+
+
+@pytest.mark.unit
+def test_default_pool_size_128():
+    from app.providers.bedrock_adapter import _BEDROCK_POOL_SIZE
+    assert _BEDROCK_POOL_SIZE == 128 or _BEDROCK_POOL_SIZE > 0

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/regression/test_scope_denial_400.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/regression/test_scope_denial_400.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Amazon.com
+"""Regression: scope denial returns 400 (not 403) to prevent Claude Code /login prompt."""
+import pytest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+@pytest.mark.unit
+def test_bedrock_scope_denial_uses_invalid_request_error():
+    src = (SRC / "app/routers/bedrock.py").read_text()
+    assert "invalid_request_error" in src
+
+
+@pytest.mark.unit
+def test_messages_scope_denial_uses_400():
+    src = (SRC / "app/routers/messages.py").read_text()
+    assert "status_code=400" in src
+    assert "invalid_request_error" in src
+    assert "status_code=403" not in src or "auth" not in src.split("status_code=403")[0][-50:]
+
+
+@pytest.mark.unit
+def test_fallback_loop_scope_denial_uses_400():
+    src = (SRC / "app/services/fallback_loop.py").read_text()
+    assert "status=400" in src
+
+
+@pytest.mark.unit
+def test_openai_compat_no_403_for_scope():
+    src = (SRC / "app/routers/openai_compat.py").read_text()
+    assert "invalid_request_error" in src
+    lines = src.split("\n")
+    for i, line in enumerate(lines):
+        if "check_key_scope" in line:
+            block = "\n".join(lines[i:i+8])
+            assert "403" not in block, f"openai_compat.py still has 403 near scope check"


### PR DESCRIPTION
## Summary

- **12 bug fixes** ported from Samsung DS Phase2 production feedback (scope denial 403→400, Bedrock dedicated ThreadPool, sync_all OOM/savepoint/N+1, IPv6 healthcheck, gateway-cli fixes, DB seed, KPI undercount, seed_spent Redis refresh)
- **README ko+en**: New "Advantages over Other Open-Source LLM Proxies" section (re-origination security, token accuracy, partial cost preservation, leaderless cost workers, cascade prevention)
- **Regression tests**: 8 new tests for ported fixes (scope denial + thread pool)
- **On-prem removal + i18n toggle** (from prior PR #18, included in this branch)

## Test plan

- [x] gateway-proxy regression: 66 tests PASS
- [x] admin-api regression: 10 tests PASS
- [x] Dev cluster: gateway-proxy + admin-api 1.0.52-phase2fixes deployed, healthy
- [x] Prod cluster: gateway-proxy + admin-api 1.0.52-phase2fixes deployed, HEALTHY (PG up, Redis up)