### PR TITLE
claude-code-to-agentcore: AgentCore Observability 기반 관측성 추가

### DIFF
--- a/projects/claude-code-to-agentcore/observability/guide.md
+++ b/projects/claude-code-to-agentcore/observability/guide.md
@@ -1,0 +1,159 @@
+# Observability 가이드 — AnyCompany 이커머스 에이전트
+
+이 문서는 `runtime/ecommerce_runtime.py`(Claude Agent SDK + AgentCore Runtime)의
+관측성 구성을 정리합니다. **AgentCore Observability(CloudWatch GenAI Observability)를
+기본 축**으로 하고, Claude Agent SDK 구조에서 자동 계측이 잡지 못하는 LLM 수치
+(토큰·비용)를 커스텀 메트릭으로 보완합니다.
+
+---
+
+## 1. 아키텍처
+
+```
+┌─ AgentCore Runtime 컨테이너 ────────────────────────────────┐
+│  opentelemetry-instrument (ADOT 자동 계측)                   │
+│  └─ ecommerce_runtime.py  invoke()                          │
+│       ├─ Claude Agent SDK ──▶ claude CLI (Node 서브프로세스) │
+│       │     └─ 모델 호출·도구 실행은 이 안에서 일어남          │
+│       └─ ResultMessage (토큰·비용·레이턴시·세션ID) 수신       │
+│            └─ observability.py  observe_invocation()        │
+│                 └─▶ CloudWatch 커스텀 메트릭 genai.*         │
+└─────────────────────────────────────────────────────────────┘
+     │ (ADOT: 트레이스·스팬·로그 — 자동)      │ (보완 메트릭)
+     ▼                                       ▼
+ CloudWatch GenAI Observability          CloudWatch 이상탐지 알람 4종
+ (세션·트레이스·스팬 탐색기)              (setup_anomaly_alarms.py)
+```
+
+역할 분담:
+
+| 축 | 무엇을 보여주나 | 어떻게 활성화되나 |
+|----|----------------|------------------|
+| **AgentCore Observability** (기본) | 세션 목록, 트레이스/스팬 타임라인, 런타임 로그, Transaction Search | `agentcore deploy` 시 자동 구성 (ADOT + X-Ray 전송 + 로그 전달) |
+| **genai.* 보완 메트릭** | 호출별 토큰·비용·레이턴시·도구 호출·에러 | `observability.py`가 ResultMessage 기반으로 기록 |
+| **이상탐지 알람** | 위 메트릭의 급증·급감 감지 | `setup_anomaly_alarms.py` 1회 실행 |
+
+**보완 메트릭이 필요한 이유**: Strands 등 Python 네이티브 프레임워크는 ADOT가
+LLM 호출 span(`gen_ai.*`)을 직접 잡지만, Claude Agent SDK는 모델 호출이 `claude`
+CLI 서브프로세스(Node) 안에서 일어나 Python 자동 계측에 잡히지 않습니다. 그래서
+SDK의 `ResultMessage`(토큰·비용·`duration_ms`·세션ID)를 호출 단위로 기록합니다.
+
+## 2. 구성 요소
+
+| 파일 | 위치 | 역할 |
+|------|------|------|
+| `observability.py` | `runtime/` (컨테이너에 동봉) | 호출별 CloudWatch `genai.*` 메트릭 기록 |
+| `setup_anomaly_alarms.py` | `observability/` (로컬 실행) | 이상탐지 모델 + 알람 4종 생성/삭제 |
+| ADOT (`aws-opentelemetry-distro`) | Dockerfile | 트레이스·로그를 GenAI Observability로 자동 전송 |
+| `guide.md` | `observability/` | 이 문서 |
+
+## 3. 기록되는 메트릭
+
+네임스페이스: `bedrock-agentcore` — AgentCore 관측성 데이터와 같은 네임스페이스이며,
+기본 실행 역할의 `cloudwatch:PutMetricData` 권한이 여기로 제한되어 있어 IAM 수정
+없이 동작합니다. 차원: `Agent=anycompany_ecommerce`.
+
+| 메트릭 | 단위 | 의미 |
+|--------|------|------|
+| `genai.invocation.count` | Count | 호출 수 |
+| `genai.invocation.latency` | ms | 호출 레이턴시 (`ResultMessage.duration_ms`) |
+| `genai.token.input` | Count | 입력 토큰 (캐시 생성/읽기 포함) |
+| `genai.token.output` | Count | 출력 토큰 |
+| `genai.cost.usd` | None | 호출 비용 (`ResultMessage.total_cost_usd`) |
+| `genai.tool.calls` | Count | 도구 호출 횟수 (`ToolUseBlock` 수집) |
+| `genai.error.count` | Count | 에러 발생 시에만 기록 |
+
+네임스페이스/에이전트명은 `GENAI_METRICS_NAMESPACE`, `GENAI_AGENT_NAME` 환경변수로
+변경할 수 있습니다 (별도 네임스페이스 사용 시 실행 역할에 권한 추가 필요).
+
+## 4. 활성화 방법
+
+**전부 배포만 하면 됩니다** — GenAI Observability(트레이스·세션·로그)는
+`agentcore deploy`가 자동 구성하고, 보완 메트릭은 컨테이너에 포함되어 있습니다.
+
+```bash
+cd runtime
+python ecommerce_runtime.py deploy
+```
+
+**이상탐지 알람** (선택, 1회):
+
+```bash
+python observability/setup_anomaly_alarms.py                          # 생성/갱신
+python observability/setup_anomaly_alarms.py --sns-topic-arn arn:...  # SNS 알림 연동
+python observability/setup_anomaly_alarms.py --delete                 # 정리
+```
+
+레이턴시·입력 토큰은 양방향(급증·급감), 에러·비용은 상방만 감시합니다
+(5분 주기, 3회 평가 중 2회 밴드 이탈 시 발화, `TreatMissingData=notBreaching`).
+
+## 5. 테스트 / 확인
+
+```bash
+# 1) 트래픽 생성
+python runtime/ecommerce_runtime.py invoke "3월 베스트셀러 TOP5 알려줘"
+
+# 2) 세션·트레이스: GenAI Observability 대시보드 (첫 데이터는 최대 10분 지연)
+#    https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#gen-ai-observability/agent-core
+#    → Agent Core → 에이전트 선택 → Sessions / Traces 탭
+
+# 3) 메트릭: CloudWatch → Metrics → bedrock-agentcore → Agent 차원
+aws cloudwatch get-metric-data --region us-east-1 \
+  --start-time "$(date -u -v-1H +%Y-%m-%dT%H:%M:%S)" --end-time "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+  --metric-data-queries '[{"Id":"c","MetricStat":{"Metric":{"Namespace":"bedrock-agentcore",
+    "MetricName":"genai.cost.usd","Dimensions":[{"Name":"Agent","Value":"anycompany_ecommerce"}]},
+    "Period":300,"Stat":"Sum"}}]'
+
+# 4) 런타임 로그
+aws logs tail /aws/bedrock-agentcore/runtimes/<runtime-id>-DEFAULT --since 1h
+
+# 5) 알람: CloudWatch → Alarms → anycompany_ecommerce-genai.*-anomaly
+```
+
+**이상탐지 밴드는 등록 직후 "Insufficient data"가 정상**입니다. 수 시간~수 일의
+트래픽으로 학습된 뒤 그래프에 회색 예상 밴드가 나타납니다. 테스트로 이상을
+유발하려면 평소보다 훨씬 긴 프롬프트(토큰 급증)나 연속 다량 호출(비용 급증)을
+보내보세요.
+
+## 6. 비용: 세션별로 비용이 추가되는가?
+
+**예. 세션마다 추가 비용이 발생합니다.** AgentCore Runtime은 세션(=microVM) 단위로
+소비 기반 과금됩니다 ([공식 요금](https://aws.amazon.com/bedrock/agentcore/pricing/) 기준):
+
+| 리소스 | 단가 | 과금 시점 |
+|--------|------|-----------|
+| CPU | $0.0895 / vCPU-시간 | **활성 처리 중에만** — LLM 응답·도구 호출을 기다리는 I/O 대기 중에는 과금 없음 |
+| 메모리 | $0.00945 / GB-시간 | **세션이 살아있는 전체 시간** — 유휴(idle) 구간 포함, 초 단위 |
+
+세션 수명 주기 ([공식 문서](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html)):
+- 유휴 타임아웃 기본 **15분** (LifecycleConfiguration으로 60초~8시간 조정 가능)
+- 최대 수명 **8시간** (호출로 리셋되지 않음)
+- `StopRuntimeSession` API로 즉시 종료 가능
+
+**이 프로젝트에의 함의**: `invoke_deployed()`는 호출마다 `uuid.uuid4().hex * 2`로
+**새 세션**을 만듭니다. 즉 호출이 끝나도 microVM이 기본 15분간 유휴 상태로 살아있고,
+그동안 **메모리 요금이 계속 쌓입니다**. 이 컨테이너는 Node + Claude CLI를 포함해
+메모리 풋프린트가 작지 않으므로(피크 ~2GB 가정 시 세션당 유휴 비용 ≈ 2GB × 0.25h ×
+$0.00945 ≈ **$0.005/세션**), 호출량이 많아지면 무시할 수 없습니다.
+
+절감 방법:
+1. **세션 재사용** — 같은 사용자/대화는 동일 `runtimeSessionId`로 호출 (유휴 VM을 새로 만들지 않음)
+2. **유휴 타임아웃 단축** — 런타임의 `lifecycleConfiguration.idleRuntimeSessionTimeout`을 60~300초로 설정
+3. **명시적 종료** — 일회성 배치 호출이라면 완료 후 `StopRuntimeSession` 호출
+
+참고로 관측성 자체의 비용은 미미합니다: 커스텀 메트릭 7종 × 1차원(~$0.30/메트릭/월
+수준 고정), 이상탐지 모델·알람 4종(알람당 ~$0.30/월 수준). GenAI Observability는
+Transaction Search 기반으로 수집 span 양에 따라 CloudWatch 요금이 발생하지만 이
+프로젝트 트래픽 수준에서는 무시할 만합니다.
+
+## 7. 트러블슈팅
+
+- **메트릭이 안 보임**: 런타임 로그에서 `put_metric_data 실패` 경고 확인.
+  커스텀 네임스페이스를 쓴 경우 실행 역할에 해당 네임스페이스의
+  `cloudwatch:PutMetricData` 권한이 있는지 확인하세요 (기본 역할은 `bedrock-agentcore`만 허용).
+- **`get-metric-statistics`가 빈 결과**: `get-metric-data`로 조회하세요 (기간 정렬에 덜 민감).
+- **GenAI Observability에 트레이스가 안 보임**: 첫 배포 후 최대 10분 지연이 정상.
+  CloudWatch 콘솔에서 Transaction Search가 활성화돼 있는지 확인 (`agentcore deploy`가
+  자동 구성하지만, 계정 최초 1회는 반영에 시간이 걸릴 수 있음).
+- **알람이 계속 Insufficient data**: 이상탐지 모델 학습에 트래픽 이력이 필요합니다.
+  주기적으로 호출을 보내며 수 시간 이상 기다리세요.

--- a/projects/claude-code-to-agentcore/observability/guide.md
+++ b/projects/claude-code-to-agentcore/observability/guide.md
@@ -2,8 +2,15 @@
 
 이 문서는 `runtime/ecommerce_runtime.py`(Claude Agent SDK + AgentCore Runtime)의
 관측성 구성을 정리합니다. **AgentCore Observability(CloudWatch GenAI Observability)를
-기본 축**으로 하고, Claude Agent SDK 구조에서 자동 계측이 잡지 못하는 LLM 수치
-(토큰·비용)를 커스텀 메트릭으로 보완합니다.
+기본 축**으로 하고, Claude Agent SDK 구조에서 자동 계측이 잡지 못하는 LLM 데이터
+(토큰·비용·프롬프트)를 gen_ai 스팬·커스텀 메트릭·구조화 로그로 보완합니다.
+
+> **AgentCore Observability는 어디서 보나?** AgentCore Observability는 기능 이름이고,
+> 공식 확인 화면은 CloudWatch 콘솔의 GenAI Observability → Agent Core 탭입니다
+> (AgentCore 서비스 콘솔의 Observability 메뉴도 같은 화면으로 연결).
+> Transaction Search가 저장하는 스팬(`aws/spans` 로그 그룹) 기반으로 에이전트 →
+> 세션 → 트레이스 타임라인 → 스팬 상세로 내려가며 탐색합니다.
+> `agentcore deploy` 출력의 "GenAI Observability Dashboard" 링크가 이 화면입니다.
 
 ---
 
@@ -17,9 +24,12 @@
 │       │     └─ 모델 호출·도구 실행은 이 안에서 일어남          │
 │       └─ ResultMessage (토큰·비용·레이턴시·세션ID) 수신       │
 │            └─ observability.py  observe_invocation()        │
-│                 └─▶ CloudWatch 커스텀 메트릭 genai.*         │
+│                 ├─▶ gen_ai 스팬 (claude_agent_sdk.invoke_agent│
+│                 │    — 프롬프트·응답·토큰, 기존 트레이스에 연결)│
+│                 ├─▶ CloudWatch 커스텀 메트릭 genai.*         │
+│                 └─▶ GENAI_INVOCATION 구조화 로그 (입출력 전문)│
 └─────────────────────────────────────────────────────────────┘
-     │ (ADOT: 트레이스·스팬·로그 — 자동)      │ (보완 메트릭)
+     │ (스팬: ADOT 자동 + gen_ai 수동)        │ (보완 메트릭)
      ▼                                       ▼
  CloudWatch GenAI Observability          CloudWatch 이상탐지 알람 4종
  (세션·트레이스·스팬 탐색기)              (setup_anomaly_alarms.py)
@@ -30,22 +40,41 @@
 | 축 | 무엇을 보여주나 | 어떻게 활성화되나 |
 |----|----------------|------------------|
 | **AgentCore Observability** (기본) | 세션 목록, 트레이스/스팬 타임라인, 런타임 로그, Transaction Search | `agentcore deploy` 시 자동 구성 (ADOT + X-Ray 전송 + 로그 전달) |
-| **genai.* 보완 메트릭** | 호출별 토큰·비용·레이턴시·도구 호출·에러 | `observability.py`가 ResultMessage 기반으로 기록 |
-| **이상탐지 알람** | 위 메트릭의 급증·급감 감지 | `setup_anomaly_alarms.py` 1회 실행 |
+| **gen_ai 스팬** (보완) | 콘솔 트레이스 상세에서 프롬프트·응답 전문·토큰·비용 | `observability.py`가 호출마다 발행 (content는 옵트인) |
+| **genai.* 보완 메트릭** | 호출별 토큰·비용·레이턴시·도구 호출·에러 추이 | `observability.py`가 ResultMessage 기반으로 기록 |
+| **GENAI_INVOCATION 로그** | 입출력 전문 대량 조회 (Logs Insights) | `observability.py`가 기록 (옵트인) |
+| **이상탐지 알람** | genai.* 메트릭의 급증·급감 감지 | `setup_anomaly_alarms.py` 1회 실행 |
 
-**보완 메트릭이 필요한 이유**: Strands 등 Python 네이티브 프레임워크는 ADOT가
-LLM 호출 span(`gen_ai.*`)을 직접 잡지만, Claude Agent SDK는 모델 호출이 `claude`
-CLI 서브프로세스(Node) 안에서 일어나 Python 자동 계측에 잡히지 않습니다. 그래서
-SDK의 `ResultMessage`(토큰·비용·`duration_ms`·세션ID)를 호출 단위로 기록합니다.
+**보완이 필요한 이유**: Strands 등 Python 네이티브 프레임워크는 ADOT가 LLM 호출
+span(`gen_ai.*`)을 직접 잡지만, Claude Agent SDK는 모델 호출이 `claude` CLI
+서브프로세스(Node) 안에서 일어나 Python 자동 계측에 잡히지 않습니다. 그래서 SDK의
+`ResultMessage`(토큰·비용·`duration_ms`·세션ID)를 호출 단위로 스팬·메트릭·로그에
+기록합니다.
 
 ## 2. 구성 요소
 
 | 파일 | 위치 | 역할 |
 |------|------|------|
-| `observability.py` | `runtime/` (컨테이너에 동봉) | 호출별 CloudWatch `genai.*` 메트릭 기록 |
+| `observability.py` | `runtime/` (컨테이너에 동봉) | gen_ai 스팬 발행 + `genai.*` 메트릭 + `GENAI_INVOCATION` 로그 |
 | `setup_anomaly_alarms.py` | `observability/` (로컬 실행) | 이상탐지 모델 + 알람 4종 생성/삭제 |
 | ADOT (`aws-opentelemetry-distro`) | Dockerfile | 트레이스·로그를 GenAI Observability로 자동 전송 |
 | `guide.md` | `observability/` | 이 문서 |
+
+## 2-1. 입력/출력 프롬프트 확인 (콘솔 + 로그)
+
+호출마다 `claude_agent_sdk.invoke_agent` gen_ai 스팬이 기존 트레이스에 발행됩니다.
+AgentCore Observability에서 **Agent Core → 에이전트 → 세션 선택 → 트레이스 → 스팬 클릭**하면
+`gen_ai.input.messages` / `gen_ai.output.messages`(요청·응답 전문),
+`gen_ai.usage.input_tokens/output_tokens`, `cost_usd`, `gen_ai.tool.names`가 보입니다.
+
+같은 내용이 `GENAI_INVOCATION` 구조화 로그로도 남아 Logs Insights로 대량 조회할 수
+있습니다: `filter log_type = "GENAI_INVOCATION" | fields session_id, request_payload,
+response_payload, cost_usd`
+
+**옵트인**: 프롬프트 원문에는 PII가 포함될 수 있어 기본 비활성입니다. `deploy()`가
+`GENAI_LOG_PAYLOADS=1`(로그·스팬 content 게이트)과
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`(ADOT의 content 속성
+제거 방지)를 명시적으로 주입합니다. 끄려면 두 환경변수를 제거하고 재배포하세요.
 
 ## 3. 기록되는 메트릭
 

--- a/projects/claude-code-to-agentcore/observability/setup_anomaly_alarms.py
+++ b/projects/claude-code-to-agentcore/observability/setup_anomaly_alarms.py
@@ -1,0 +1,89 @@
+"""
+setup_anomaly_alarms.py — agentops-kit infra/anomaly_setup.py 를 이 runtime의
+genai.* 메트릭(observability.py 가 기록)에 맞게 각색한 CloudWatch 이상탐지 설정.
+
+메트릭별로 ML 기반 이상탐지 모델(put_anomaly_detector)을 등록하고,
+ANOMALY_DETECTION_BAND 밴드를 벗어나면 울리는 알람(put_metric_alarm)을 만듭니다.
+이상탐지 모델은 등록 후 실제 트래픽 데이터가 수 시간~수 일 쌓여야 밴드가 안정화됩니다.
+
+사용:
+    python setup_anomaly_alarms.py                              # 알람 생성/갱신
+    python setup_anomaly_alarms.py --sns-topic-arn arn:aws:sns:...  # 알림 연동
+    python setup_anomaly_alarms.py --delete                     # 정리
+"""
+import argparse
+import os
+
+import boto3
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+NAMESPACE = os.environ.get("GENAI_METRICS_NAMESPACE", "bedrock-agentcore")
+AGENT_NAME = os.environ.get("GENAI_AGENT_NAME", "anycompany_ecommerce")
+DIMENSIONS = [{"Name": "Agent", "Value": AGENT_NAME}]
+
+# (메트릭, 통계, 밴드 폭, 비교 연산자) — agentops-kit 과 동일한 5분/3평가/2트리거 정책.
+# 레이턴시·토큰은 양방향(급증·급감 모두 이상), 에러·비용은 상방만 감시합니다.
+MONITORED = [
+    ("genai.invocation.latency", "Average", 2, "LessThanLowerOrGreaterThanUpperThreshold"),
+    ("genai.token.input", "Average", 3, "LessThanLowerOrGreaterThanUpperThreshold"),
+    ("genai.error.count", "Sum", 2, "GreaterThanUpperThreshold"),
+    ("genai.cost.usd", "Sum", 3, "GreaterThanUpperThreshold"),
+]
+
+
+def alarm_name(metric: str) -> str:
+    return f"{AGENT_NAME}-{metric}-anomaly"
+
+
+def setup(sns_topic_arn: str | None):
+    cw = boto3.client("cloudwatch", region_name=REGION)
+    for metric, stat, band, operator in MONITORED:
+        cw.put_anomaly_detector(SingleMetricAnomalyDetector={
+            "Namespace": NAMESPACE, "MetricName": metric,
+            "Dimensions": DIMENSIONS, "Stat": stat})
+        cw.put_metric_alarm(
+            AlarmName=alarm_name(metric),
+            AlarmDescription=f"{AGENT_NAME} {metric} 이상탐지 (band={band})",
+            Metrics=[
+                {"Id": "m1", "ReturnData": True,
+                 "MetricStat": {"Metric": {"Namespace": NAMESPACE, "MetricName": metric,
+                                           "Dimensions": DIMENSIONS},
+                                "Period": 300, "Stat": stat}},
+                {"Id": "ad1", "ReturnData": True,
+                 "Expression": f"ANOMALY_DETECTION_BAND(m1, {band})",
+                 "Label": f"{metric} (expected)"},
+            ],
+            ThresholdMetricId="ad1",
+            ComparisonOperator=operator,
+            EvaluationPeriods=3,
+            DatapointsToAlarm=2,
+            TreatMissingData="notBreaching",
+            ActionsEnabled=bool(sns_topic_arn),
+            AlarmActions=[sns_topic_arn] if sns_topic_arn else [],
+        )
+        print(f"  ok: {alarm_name(metric)} ({stat}, band={band})")
+    print(f"\n{len(MONITORED)}개 이상탐지 알람 구성 완료 "
+          f"(namespace={NAMESPACE}, region={REGION})")
+    if not sns_topic_arn:
+        print("알림을 받으려면 --sns-topic-arn 으로 다시 실행하세요.")
+
+
+def delete():
+    cw = boto3.client("cloudwatch", region_name=REGION)
+    cw.delete_alarms(AlarmNames=[alarm_name(m) for m, *_ in MONITORED])
+    for metric, stat, _, _ in MONITORED:
+        try:
+            cw.delete_anomaly_detector(SingleMetricAnomalyDetector={
+                "Namespace": NAMESPACE, "MetricName": metric,
+                "Dimensions": DIMENSIONS, "Stat": stat})
+        except cw.exceptions.ResourceNotFoundException:
+            pass
+    print("이상탐지 알람/모델 삭제 완료")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sns-topic-arn", help="알람 발생 시 알림을 보낼 SNS 토픽 ARN")
+    parser.add_argument("--delete", action="store_true", help="알람/이상탐지 모델 삭제")
+    args = parser.parse_args()
+    delete() if args.delete else setup(args.sns_topic_arn)

--- a/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
+++ b/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
@@ -143,6 +143,10 @@ async def invoke(payload: dict):
                     result = msg
                     if msg.is_error and not error:
                         error = f"result.subtype={msg.subtype}"
+    except GeneratorExit:
+        # 클라이언트가 스트림을 중단한 경우 — 정상 호출로 집계되지 않도록 표시.
+        error = "client_disconnect"
+        raise
     except Exception as e:
         error = repr(e)
         raise

--- a/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
+++ b/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
@@ -17,20 +17,31 @@ Part 1의 로컬 `local_agent/agent.py` 와 **에이전트 로직은 동일**합
     python ecommerce_runtime.py deploy        # configure + deploy (컨테이너, CodeBuild)
     python ecommerce_runtime.py invoke "..."  # 배포된 런타임 호출
     python ecommerce_runtime.py               # 로컬 :8080 (컨테이너 진입점)
+
+관측성 (AgentCore Observability 기준):
+    트레이스·스팬·로그는 ADOT 자동 계측이 CloudWatch GenAI Observability로 전송(기본 제공).
+    토큰·비용 등 LLM 수치는 observability.py가 호출마다 genai.* 메트릭으로 보완 기록.
+    python ../observability/setup_anomaly_alarms.py  # 이상탐지 알람 구성 (선택)
+    전체 가이드: ../observability/guide.md
 """
 import json
 import os
 import shutil
 import subprocess
 import sys
+import time
 
 from bedrock_agentcore import BedrockAgentCoreApp
 from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    ResultMessage,
     TextBlock,
+    ToolUseBlock,
 )
+
+import observability
 
 REGION = "us-east-1"
 MODEL_ID = "us.anthropic.claude-sonnet-4-6"
@@ -108,13 +119,47 @@ app = BedrockAgentCoreApp()
 
 @app.entrypoint
 async def invoke(payload: dict):
-    async with ClaudeSDKClient(options=build_options()) as client:
-        await client.query(payload["prompt"])
-        async for msg in client.receive_response():
-            if isinstance(msg, AssistantMessage):
-                for block in msg.content:
-                    if isinstance(block, TextBlock):
-                        yield block.text
+    # 관측성: 스트리밍하는 동안 응답 텍스트/도구 호출을 모으고, 스트림 마지막의
+    # ResultMessage(토큰·비용·레이턴시)를 받아 CloudWatch genai.* 메트릭으로 기록합니다.
+    # 트레이스·스팬은 ADOT 자동 계측이 GenAI Observability로 전송 (observability.py 참고).
+    prompt = payload["prompt"]
+    t0 = time.monotonic()
+    chunks: list[str] = []
+    tools_used: list[str] = []
+    result: ResultMessage | None = None
+    error: str | None = None
+    try:
+        async with ClaudeSDKClient(options=build_options()) as client:
+            await client.query(prompt)
+            async for msg in client.receive_response():
+                if isinstance(msg, AssistantMessage):
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            chunks.append(block.text)
+                            yield block.text
+                        elif isinstance(block, ToolUseBlock):
+                            tools_used.append(block.name)
+                elif isinstance(msg, ResultMessage):
+                    result = msg
+                    if msg.is_error and not error:
+                        error = f"result.subtype={msg.subtype}"
+    except Exception as e:
+        error = repr(e)
+        raise
+    finally:
+        observability.observe_invocation(
+            prompt=prompt,
+            response="".join(chunks),
+            model=MODEL_ID,
+            latency_ms=(result.duration_ms if result
+                        else int((time.monotonic() - t0) * 1000)),
+            usage=(result.usage if result else None) or {},
+            cost_usd=(result.total_cost_usd if result else None) or 0.0,
+            session_id=result.session_id if result else None,
+            num_turns=result.num_turns if result else None,
+            tools_used=tools_used,
+            error=error,
+        )
 
 
 # ───────────────────────── Configure + Deploy ───────────────────────────────
@@ -164,6 +209,7 @@ def deploy():
     os.makedirs(build, exist_ok=True)
     entry = os.path.basename(__file__)
     shutil.copy(os.path.abspath(__file__), os.path.join(build, entry))
+    shutil.copy(os.path.join(here, "observability.py"), os.path.join(build, "observability.py"))
     with open(os.path.join(build, "requirements.txt"), "w") as f:
         f.write(REQUIREMENTS)
     for stale in (".bedrock_agentcore.yaml",):

--- a/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
+++ b/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
@@ -232,9 +232,10 @@ def deploy():
         "--env", f"ECOMMERCE_GW_URL={gw_info['gateway_url']}",
         "--env", f"ECOMMERCE_GW_CLIENT={json.dumps(gw_info['client_info'])}",
         "--env", f"WEB_SEARCH_GW_URL={WEB_SEARCH_GW_URL}",
-        # 호출별 입력/출력 프롬프트 로깅(GENAI_INVOCATION) 옵트인. 원문에 PII가
-        # 포함될 수 있으므로 프로덕션에서는 필요할 때만 켜세요.
+        # 호출별 입력/출력 프롬프트 로깅(GENAI_INVOCATION) + gen_ai 스팬 content 옵트인.
+        # 원문에 PII가 포함될 수 있으므로 프로덕션에서는 필요할 때만 켜세요.
         "--env", "GENAI_LOG_PAYLOADS=1",
+        "--env", "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true",
     ]
     print(">> deploy (CodeBuild ARM64)")
     subprocess.run([ac, "deploy", "--auto-update-on-conflict", *envs],

--- a/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
+++ b/projects/claude-code-to-agentcore/runtime/ecommerce_runtime.py
@@ -232,6 +232,9 @@ def deploy():
         "--env", f"ECOMMERCE_GW_URL={gw_info['gateway_url']}",
         "--env", f"ECOMMERCE_GW_CLIENT={json.dumps(gw_info['client_info'])}",
         "--env", f"WEB_SEARCH_GW_URL={WEB_SEARCH_GW_URL}",
+        # 호출별 입력/출력 프롬프트 로깅(GENAI_INVOCATION) 옵트인. 원문에 PII가
+        # 포함될 수 있으므로 프로덕션에서는 필요할 때만 켜세요.
+        "--env", "GENAI_LOG_PAYLOADS=1",
     ]
     print(">> deploy (CodeBuild ARM64)")
     subprocess.run([ac, "deploy", "--auto-update-on-conflict", *envs],

--- a/projects/claude-code-to-agentcore/runtime/observability.py
+++ b/projects/claude-code-to-agentcore/runtime/observability.py
@@ -26,9 +26,10 @@ log = logging.getLogger("observability")
 # 별도 네임스페이스를 쓰려면 실행 역할에 해당 네임스페이스 권한을 추가하세요.
 METRICS_NAMESPACE = os.environ.get("GENAI_METRICS_NAMESPACE", "bedrock-agentcore")
 AGENT_NAME = os.environ.get("GENAI_AGENT_NAME", "anycompany_ecommerce")
-# 프롬프트/응답 원문 로깅 여부. 원문에는 고객 데이터·PII가 포함될 수 있으므로
-# 로그 보존 기간·접근 권한을 함께 관리하고, 불필요하면 GENAI_LOG_PAYLOADS=0 으로 끄세요.
-LOG_PAYLOADS = os.environ.get("GENAI_LOG_PAYLOADS", "1") != "0"
+# 프롬프트/응답 원문 로깅 여부 — 기본 비활성(옵트인). 원문에는 고객 데이터·PII가
+# 포함될 수 있으므로, 켤 때는(GENAI_LOG_PAYLOADS=1) 로그 보존 기간·접근 권한을
+# 함께 관리하세요. 이 프로젝트의 deploy()는 실습을 위해 명시적으로 켭니다.
+LOG_PAYLOADS = os.environ.get("GENAI_LOG_PAYLOADS", "0") == "1"
 
 _cloudwatch = None
 

--- a/projects/claude-code-to-agentcore/runtime/observability.py
+++ b/projects/claude-code-to-agentcore/runtime/observability.py
@@ -12,12 +12,17 @@ AgentCore Runtime은 배포만 하면 ADOT(`opentelemetry-instrument`) 자동 �
      `genai.*` 로 기록 — 이상탐지 알람(observability/setup_anomaly_alarms.py) 대상.
   2) 호출별 입력/출력 프롬프트 전문을 구조화 JSON 로그(GENAI_INVOCATION)로 기록 —
      런타임 로그 그룹에서 CloudWatch Logs Insights로 session_id별 조회 가능.
+  3) OTel gen_ai 스팬 발행 — Strands 등이 자동으로 하는 것을 Claude Agent SDK에
+     맞게 수동 발행. ADOT가 이미 설정한 전역 tracer를 재사용하므로 기존 트레이스
+     (POST /invocations 하위)에 끼어 들어가고, GenAI Observability 콘솔의 트레이스
+     상세에서 스팬을 클릭하면 프롬프트·응답·토큰이 속성으로 보입니다.
 
 기록 실패는 에이전트 응답에 영향을 주지 않습니다 (로그만 남김).
 """
 import json
 import logging
 import os
+import time
 
 log = logging.getLogger("observability")
 
@@ -47,12 +52,45 @@ def observe_invocation(*, prompt: str, response: str, model: str,
                        latency_ms: int, usage: dict, cost_usd: float,
                        session_id: str | None = None, num_turns: int | None = None,
                        tools_used: list[str] | None = None, error: str | None = None):
-    """호출 1건의 메트릭을 기록. 스트리밍 종료(finally) 시점에 호출."""
+    """호출 1건의 메트릭·gen_ai 스팬·페이로드 로그를 기록. 스트리밍 종료(finally) 시점에 호출."""
     tools_used = tools_used or []
     input_tokens = (usage.get("input_tokens", 0)
                     + usage.get("cache_creation_input_tokens", 0)
                     + usage.get("cache_read_input_tokens", 0))
     output_tokens = usage.get("output_tokens", 0)
+
+    # GenAI Observability 콘솔의 트레이스 상세에서 입출력을 보여주는 gen_ai 스팬.
+    try:
+        from opentelemetry import trace as otel_trace
+        end_ns = time.time_ns()
+        span = otel_trace.get_tracer("observability").start_span(
+            "claude_agent_sdk.invoke_agent",
+            start_time=end_ns - int(latency_ms * 1_000_000),
+            attributes={
+                "gen_ai.system": "claude-agent-sdk",
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.agent.name": AGENT_NAME,
+                "gen_ai.request.model": model,
+                "gen_ai.usage.input_tokens": input_tokens,
+                "gen_ai.usage.output_tokens": output_tokens,
+                "gen_ai.conversation.id": session_id or "",
+                "gen_ai.tool.names": ",".join(tools_used),
+                "cost_usd": cost_usd,
+            })
+        if LOG_PAYLOADS:
+            # 컨테이너에 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true 가
+            # 있어야 ADOT가 content 속성을 제거하지 않고 내보냅니다 (deploy()가 주입).
+            span.set_attribute("gen_ai.input.messages", json.dumps(
+                [{"role": "user", "parts": [{"type": "text", "content": prompt}]}],
+                ensure_ascii=False))
+            span.set_attribute("gen_ai.output.messages", json.dumps(
+                [{"role": "assistant", "parts": [{"type": "text", "content": response}]}],
+                ensure_ascii=False))
+        if error:
+            span.set_status(otel_trace.StatusCode.ERROR, error)
+        span.end(end_time=end_ns)
+    except Exception as e:  # noqa: BLE001
+        log.warning("gen_ai 스팬 발행 실패: %s", e)
 
     dims = [{"Name": "Agent", "Value": AGENT_NAME}]
     data = [

--- a/projects/claude-code-to-agentcore/runtime/observability.py
+++ b/projects/claude-code-to-agentcore/runtime/observability.py
@@ -43,8 +43,13 @@ def _cw():
     global _cloudwatch
     if _cloudwatch is None:
         import boto3
+        from botocore.config import Config
+        # invoke()의 finally에서 동기 호출되므로, CloudWatch 장애 시 응답 스트림
+        # 종료가 늘어지지 않도록 타임아웃을 짧게 잡고 재시도하지 않습니다.
         _cloudwatch = boto3.client(
-            "cloudwatch", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+            "cloudwatch", region_name=os.environ.get("AWS_REGION", "us-east-1"),
+            config=Config(connect_timeout=2, read_timeout=2,
+                          retries={"max_attempts": 0}))
     return _cloudwatch
 
 
@@ -54,10 +59,12 @@ def observe_invocation(*, prompt: str, response: str, model: str,
                        tools_used: list[str] | None = None, error: str | None = None):
     """호출 1건의 메트릭·gen_ai 스팬·페이로드 로그를 기록. 스트리밍 종료(finally) 시점에 호출."""
     tools_used = tools_used or []
-    input_tokens = (usage.get("input_tokens", 0)
-                    + usage.get("cache_creation_input_tokens", 0)
-                    + usage.get("cache_read_input_tokens", 0))
-    output_tokens = usage.get("output_tokens", 0)
+    # usage 필드가 null로 올 수도 있으므로 `or 0`으로 방어 (finally에서 호출되는
+    # 함수라 여기서 예외가 새면 원래 예외를 가리거나 정상 응답 종료를 깨뜨림).
+    input_tokens = ((usage.get("input_tokens") or 0)
+                    + (usage.get("cache_creation_input_tokens") or 0)
+                    + (usage.get("cache_read_input_tokens") or 0))
+    output_tokens = usage.get("output_tokens") or 0
 
     # GenAI Observability 콘솔의 트레이스 상세에서 입출력을 보여주는 gen_ai 스팬.
     try:

--- a/projects/claude-code-to-agentcore/runtime/observability.py
+++ b/projects/claude-code-to-agentcore/runtime/observability.py
@@ -6,13 +6,16 @@ AgentCore Runtime은 배포만 하면 ADOT(`opentelemetry-instrument`) 자동 �
 다만 Claude Agent SDK는 모델 호출이 `claude` CLI 서브프로세스(Node) 안에서 일어나
 토큰·비용 같은 LLM 수치는 자동 계측에 잡히지 않습니다.
 
-이 모듈은 그 공백을 메웁니다: SDK가 스트림 마지막에 돌려주는 ResultMessage
-(토큰·비용·레이턴시·세션ID)를 AgentCore 관측성 네임스페이스(`bedrock-agentcore`)의
-CloudWatch 커스텀 메트릭 `genai.*` 로 기록합니다. 이 메트릭이 이상탐지 알람
-(observability/setup_anomaly_alarms.py)의 대상입니다.
+이 모듈은 그 공백을 메웁니다:
+  1) SDK가 스트림 마지막에 돌려주는 ResultMessage(토큰·비용·레이턴시·세션ID)를
+     AgentCore 관측성 네임스페이스(`bedrock-agentcore`)의 CloudWatch 커스텀 메트릭
+     `genai.*` 로 기록 — 이상탐지 알람(observability/setup_anomaly_alarms.py) 대상.
+  2) 호출별 입력/출력 프롬프트 전문을 구조화 JSON 로그(GENAI_INVOCATION)로 기록 —
+     런타임 로그 그룹에서 CloudWatch Logs Insights로 session_id별 조회 가능.
 
 기록 실패는 에이전트 응답에 영향을 주지 않습니다 (로그만 남김).
 """
+import json
 import logging
 import os
 
@@ -23,6 +26,9 @@ log = logging.getLogger("observability")
 # 별도 네임스페이스를 쓰려면 실행 역할에 해당 네임스페이스 권한을 추가하세요.
 METRICS_NAMESPACE = os.environ.get("GENAI_METRICS_NAMESPACE", "bedrock-agentcore")
 AGENT_NAME = os.environ.get("GENAI_AGENT_NAME", "anycompany_ecommerce")
+# 프롬프트/응답 원문 로깅 여부. 원문에는 고객 데이터·PII가 포함될 수 있으므로
+# 로그 보존 기간·접근 권한을 함께 관리하고, 불필요하면 GENAI_LOG_PAYLOADS=0 으로 끄세요.
+LOG_PAYLOADS = os.environ.get("GENAI_LOG_PAYLOADS", "1") != "0"
 
 _cloudwatch = None
 
@@ -64,3 +70,26 @@ def observe_invocation(*, prompt: str, response: str, model: str,
         _cw().put_metric_data(Namespace=METRICS_NAMESPACE, MetricData=data)
     except Exception as e:  # noqa: BLE001
         log.warning("CloudWatch put_metric_data 실패: %s", e)
+
+    # 호출별 입력/출력 전문 — 런타임 로그 그룹의 [runtime-logs] 스트림으로 수집됨.
+    # Logs Insights 예: filter log_type = "GENAI_INVOCATION" | fields session_id,
+    #                   request_payload, response_payload, cost_usd
+    if LOG_PAYLOADS:
+        try:
+            print(json.dumps({
+                "log_type": "GENAI_INVOCATION",
+                "agent": AGENT_NAME,
+                "session_id": session_id,
+                "model": model,
+                "latency_ms": latency_ms,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cost_usd": cost_usd,
+                "num_turns": num_turns,
+                "tools_used": tools_used,
+                "error": error,
+                "request_payload": prompt,
+                "response_payload": response,
+            }, ensure_ascii=False), flush=True)
+        except Exception as e:  # noqa: BLE001
+            log.warning("페이로드 로그 기록 실패: %s", e)

--- a/projects/claude-code-to-agentcore/runtime/observability.py
+++ b/projects/claude-code-to-agentcore/runtime/observability.py
@@ -1,0 +1,66 @@
+"""
+observability.py — AgentCore Observability를 보완하는 호출 단위 메트릭 기록.
+
+AgentCore Runtime은 배포만 하면 ADOT(`opentelemetry-instrument`) 자동 계측으로
+트레이스·스팬·로그를 CloudWatch GenAI Observability(Transaction Search)에 보냅니다.
+다만 Claude Agent SDK는 모델 호출이 `claude` CLI 서브프로세스(Node) 안에서 일어나
+토큰·비용 같은 LLM 수치는 자동 계측에 잡히지 않습니다.
+
+이 모듈은 그 공백을 메웁니다: SDK가 스트림 마지막에 돌려주는 ResultMessage
+(토큰·비용·레이턴시·세션ID)를 AgentCore 관측성 네임스페이스(`bedrock-agentcore`)의
+CloudWatch 커스텀 메트릭 `genai.*` 로 기록합니다. 이 메트릭이 이상탐지 알람
+(observability/setup_anomaly_alarms.py)의 대상입니다.
+
+기록 실패는 에이전트 응답에 영향을 주지 않습니다 (로그만 남김).
+"""
+import logging
+import os
+
+log = logging.getLogger("observability")
+
+# AgentCore Runtime 기본 실행 역할은 cloudwatch:PutMetricData 를
+# `bedrock-agentcore` 네임스페이스로 제한하므로 기본값으로 그대로 사용합니다.
+# 별도 네임스페이스를 쓰려면 실행 역할에 해당 네임스페이스 권한을 추가하세요.
+METRICS_NAMESPACE = os.environ.get("GENAI_METRICS_NAMESPACE", "bedrock-agentcore")
+AGENT_NAME = os.environ.get("GENAI_AGENT_NAME", "anycompany_ecommerce")
+
+_cloudwatch = None
+
+
+def _cw():
+    global _cloudwatch
+    if _cloudwatch is None:
+        import boto3
+        _cloudwatch = boto3.client(
+            "cloudwatch", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+    return _cloudwatch
+
+
+def observe_invocation(*, prompt: str, response: str, model: str,
+                       latency_ms: int, usage: dict, cost_usd: float,
+                       session_id: str | None = None, num_turns: int | None = None,
+                       tools_used: list[str] | None = None, error: str | None = None):
+    """호출 1건의 메트릭을 기록. 스트리밍 종료(finally) 시점에 호출."""
+    tools_used = tools_used or []
+    input_tokens = (usage.get("input_tokens", 0)
+                    + usage.get("cache_creation_input_tokens", 0)
+                    + usage.get("cache_read_input_tokens", 0))
+    output_tokens = usage.get("output_tokens", 0)
+
+    dims = [{"Name": "Agent", "Value": AGENT_NAME}]
+    data = [
+        {"MetricName": "genai.invocation.count", "Value": 1, "Unit": "Count"},
+        {"MetricName": "genai.invocation.latency", "Value": latency_ms, "Unit": "Milliseconds"},
+        {"MetricName": "genai.token.input", "Value": input_tokens, "Unit": "Count"},
+        {"MetricName": "genai.token.output", "Value": output_tokens, "Unit": "Count"},
+        {"MetricName": "genai.cost.usd", "Value": cost_usd, "Unit": "None"},
+        {"MetricName": "genai.tool.calls", "Value": len(tools_used), "Unit": "Count"},
+    ]
+    if error:
+        data.append({"MetricName": "genai.error.count", "Value": 1, "Unit": "Count"})
+    for d in data:
+        d["Dimensions"] = dims
+    try:
+        _cw().put_metric_data(Namespace=METRICS_NAMESPACE, MetricData=data)
+    except Exception as e:  # noqa: BLE001
+        log.warning("CloudWatch put_metric_data 실패: %s", e)


### PR DESCRIPTION
## 개요
`projects/claude-code-to-agentcore`의 AgentCore Runtime 에이전트에 **AgentCore Observability 기준** 관측성을 추가합니다.

## 배경
Claude Agent SDK는 모델 호출이 `claude` CLI 서브프로세스(Node) 안에서 일어나므로, ADOT 자동 계측(트레이스·스팬·로그)만으로는 토큰·비용·프롬프트 등 LLM 데이터가 잡히지 않습니다. SDK가 스트림 마지막에 반환하는 `ResultMessage`를 호출 단위로 기록해 이 공백을 메웁니다.

## 변경 사항
- **`runtime/observability.py`** (신규):
  - **gen_ai 스팬 발행**: 호출마다 `claude_agent_sdk.invoke_agent` 스팬을 기존 트레이스(`POST /invocations` 하위)에 발행. Strands가 자동으로 하는 것을 Claude Agent SDK에 맞게 수동 구현한 것으로, `gen_ai.input.messages`/`gen_ai.output.messages` 속성으로 프롬프트·응답 전문이 실려 **GenAI Observability 콘솔 트레이스 상세에서 입출력을 바로 확인**할 수 있습니다. 토큰·모델·비용·도구 속성 포함.
  - `ResultMessage`(토큰·비용·레이턴시·세션ID)를 `bedrock-agentcore` 네임스페이스의 CloudWatch `genai.*` 커스텀 메트릭 7종으로 기록. 기본 실행 역할 권한만으로 동작.
  - 호출별 입력/출력 전문을 구조화 로그(`GENAI_INVOCATION`)로 기록 — Logs Insights에서 `session_id`별 조회.
  - 프롬프트 원문 수집(스팬·로그 모두)은 PII 고려로 **기본 비활성(옵트인)** — `deploy()`가 `GENAI_LOG_PAYLOADS=1`과 `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`를 명시적으로 주입. 후자가 없으면 ADOT가 content 속성을 스팬에서 제거합니다.
  - 기록 실패는 에이전트 응답에 영향 없음.
- **`runtime/ecommerce_runtime.py`**: `invoke()`에 호출 단위 계측 연결(`ToolUseBlock` 수집 + `finally` 기록), 옵트인 환경변수 주입, 배포 시 모듈 동봉.
- **`observability/setup_anomaly_alarms.py`** (신규): 레이턴시·입력 토큰·에러·비용 4종에 CloudWatch ML 이상탐지 밴드 알람 생성/삭제 (agentops-kit `infra/anomaly_setup.py` 패턴 적용).
- **`observability/guide.md`** (신규): 아키텍처, 메트릭 레퍼런스, 활성화·테스트 방법, 세션 단위 비용 분석 가이드.

## 검증 (실배포 E2E)
- **gen_ai 스팬**: `aws/spans`에서 `claude_agent_sdk.invoke_agent` 스팬이 기존 트레이스에 연결(parent 有)되고, `gen_ai.input.messages`에 요청 전문("8월 예상 매출 트렌드를 한 문장으로"), `gen_ai.output.messages`에 응답 전문, `gen_ai.usage.input_tokens=70,777` 등 속성 확인
- `genai.*` 메트릭: 세션 종료 후 ~24초 내 CloudWatch 도착 확인
- `GENAI_INVOCATION` 로그: request/response 전문 + 세션ID·토큰·비용 기록 확인
- 이상탐지 알람 4종: 밴드 학습 완료 후 `OK` 상태 확인
- 서비스 스팬(`AgentCore.Runtime.Invoke`, `AgentCore.Gateway.InvokeTool.<도구명>` 등): GenAI Observability(Transaction Search) 콘솔에서 세션별 확인
