### PR TITLE
feat(awsome-ai-gateway): Bedrock/STS VPC Endpoints (PrivateLink)

### DIFF
--- a/projects/awsome-ai-gateway/README.en.md
+++ b/projects/awsome-ai-gateway/README.en.md
@@ -233,6 +233,7 @@ Examples:
 | **Minjae An** | AWS Forward Deployed DL Architect | [Email](mailto:aminjae@amazon.com) |
 | **Sue Cha** | AWS Deep Learning Architect | [Email](mailto:suecha@amazon.com) |
 | **Gonsoo Moon** | AWS Sr. AI Specialist Solutions Architect | [Email](mailto:moongons@amazon.com) |
+| **Debasish Mishra** | AWS Sr. Data Scientist | [Email](mailto:misdebas@amazon.com) |
 
 ## Contributors
 

--- a/projects/awsome-ai-gateway/README.md
+++ b/projects/awsome-ai-gateway/README.md
@@ -311,6 +311,7 @@ LLM 의 환각·재계산을 막기 위한 **deterministic-tool-first** 설계. 
 | **Minjae An** | AWS Forward Deployed DL Architect | [Email](mailto:aminjae@amazon.com) |
 | **Sue Cha** | AWS Deep Learning Architect | [Email](mailto:suecha@amazon.com) |
 | **Gonsoo Moon** | AWS Sr. AI Specialist Solutions Architect | [Email](mailto:moongons@amazon.com) |
+| **Debasish Mishra** | AWS Sr. Data Scientist | [Email](mailto:misdebas@amazon.com) |
 
 ## Contributors
 

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
@@ -23,6 +23,8 @@ locals {
 module "vpc" {
   source = "../../modules/vpc"
 
+  aws_region               = var.aws_region
+
   project                  = var.project
   environment              = var.environment
   cidr                     = var.vpc_cidr

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
@@ -19,6 +19,8 @@ locals {
 module "vpc" {
   source = "../../modules/vpc"
 
+  aws_region               = var.aws_region
+
   project                  = var.project
   environment              = var.environment
   cidr                     = var.vpc_cidr

--- a/projects/awsome-ai-gateway/deployment/terraform/modules/vpc/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/modules/vpc/main.tf
@@ -61,3 +61,79 @@ module "vpc" {
     Module      = "vpc"
   })
 }
+
+# ==============================================================================
+# VPC Endpoints — Bedrock PrivateLink (NAT 미경유, VPC 내부 직접 연결)
+# ------------------------------------------------------------------------------
+# Pod → ENI (VPC Endpoint) → Bedrock/STS. 퍼블릭 인터넷을 경유하지 않음.
+# private_dns_enabled=true: 기존 bedrock-runtime.{region}.amazonaws.com 호출이
+# 코드 변경 없이 자동으로 VPC Endpoint 프라이빗 IP로 해석됨.
+# ==============================================================================
+
+resource "aws_security_group" "vpce_bedrock" {
+  name_prefix = "${var.project}-${var.environment}-vpce-bedrock-"
+  vpc_id      = module.vpc.vpc_id
+  description = "Allow HTTPS from private subnets to Bedrock VPC Endpoint"
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+    description = "HTTPS from Fargate pods"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-vpce-bedrock"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_endpoint" "bedrock_runtime" {
+  vpc_id              = module.vpc.vpc_id
+  service_name        = "com.amazonaws.${var.aws_region}.bedrock-runtime"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.vpc.private_subnets
+  security_group_ids  = [aws_security_group.vpce_bedrock.id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-vpce-bedrock-runtime"
+  })
+}
+
+resource "aws_vpc_endpoint" "bedrock" {
+  vpc_id              = module.vpc.vpc_id
+  service_name        = "com.amazonaws.${var.aws_region}.bedrock"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.vpc.private_subnets
+  security_group_ids  = [aws_security_group.vpce_bedrock.id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-vpce-bedrock"
+  })
+}
+
+resource "aws_vpc_endpoint" "sts" {
+  vpc_id              = module.vpc.vpc_id
+  service_name        = "com.amazonaws.${var.aws_region}.sts"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.vpc.private_subnets
+  security_group_ids  = [aws_security_group.vpce_bedrock.id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-vpce-sts"
+  })
+}

--- a/projects/awsome-ai-gateway/deployment/terraform/modules/vpc/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/modules/vpc/variables.tf
@@ -45,6 +45,12 @@ variable "elasticache_subnet_cidrs" {
   type        = list(string)
 }
 
+variable "aws_region" {
+  description = "AWS region (VPC Endpoint 서비스명에 사용)"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
 variable "tags" {
   description = "공통 태그"
   type        = map(string)


### PR DESCRIPTION
## Summary

- **VPC Endpoints (PrivateLink)** for `bedrock-runtime`, `bedrock`, and `sts` added to VPC terraform module
- Pods now call Bedrock and STS via private IPs — **no NAT / internet egress**
- Cross-account flows (374/905 AssumeRole → Bedrock invoke) also route through VPC endpoints
- `aws_region` variable added to VPC module, passed from dev/prod environments
- Debasish Mishra added to Original Builders (README ko+en)

## What this changes

Before: Pod → NAT Gateway → Internet Gateway → Bedrock public endpoint
After: Pod → VPC Endpoint ENI (private IP) → Bedrock (AWS internal)

## Limitations

Mantle (Tokyo, `ap-northeast-1`) still requires NAT — VPC Endpoints are regional.

## Test plan

- [x] Prod VPC Endpoints created and `available`
- [x] Pod DNS resolves `bedrock-runtime.ap-northeast-2.amazonaws.com` → `10.40.x.x` (private)
- [x] Pod DNS resolves `sts.ap-northeast-2.amazonaws.com` → `10.40.x.x` (private)
- [x] Bedrock API reachable (AccessDenied = network OK, not timeout)
- [x] Gateway health: HEALTHY (PG up, Redis up)