### PR TITLE
fix(awsome-ai-gateway): native tool strip + thinking seal + model-aware normalizer

### DIFF
--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/services/thinking_normalizer.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/services/thinking_normalizer.py
@@ -1,0 +1,145 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Normalize the `thinking` field per target model for Bedrock/Mantle path.
+
+Anthropic changed the extended-thinking API between model generations, and the
+two shapes are mutually exclusive across models:
+
+    model                       thinking:{type:"enabled"}   thinking:{type:"adaptive"}
+    anthropic.claude-opus-4-8   400 (not supported)         200
+    anthropic.claude-opus-4-7   400 (not supported)         200
+    anthropic.claude-haiku-4-5  200                         400 (not supported)
+
+Opus 4.7+ dropped the fixed-budget form (`enabled` + `budget_tokens`) in favour
+of `adaptive` + `output_config.effort`; Haiku 4.5 predates adaptive thinking and
+only accepts the old form. The gateway normalizes here since it's the only layer
+that knows the target model.
+
+Unknown models pass through untouched: a newly-added model behaves exactly as it
+does today rather than inheriting a guessed rule. The shim never raises — worst
+case is the provider's own error, never one we introduced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Models that require `thinking:{type:"adaptive"}` and reject the legacy form.
+_ADAPTIVE_ONLY_PREFIXES: tuple[str, ...] = (
+    "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
+    "anthropic.claude-opus-5",
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-fable-5",
+    "anthropic.claude-mythos-5",
+)
+
+# Models that accept only the legacy `enabled` form and reject `adaptive`.
+_LEGACY_ONLY_PREFIXES: tuple[str, ...] = (
+    "anthropic.claude-haiku-4-5",
+)
+
+_DEFAULT_BUDGET_TOKENS = 4096
+_MIN_BUDGET_TOKENS = 1024
+
+
+def _family(provider_model_id: str | None) -> str | None:
+    """Return "adaptive", "legacy", or None (unknown — leave request alone)."""
+    if not provider_model_id:
+        return None
+    mid = provider_model_id.lower()
+    for geo in ("us.", "eu.", "apac.", "global."):
+        if mid.startswith(geo):
+            mid = mid[len(geo):]
+            break
+    if mid.startswith(_ADAPTIVE_ONLY_PREFIXES):
+        return "adaptive"
+    if mid.startswith(_LEGACY_ONLY_PREFIXES):
+        return "legacy"
+    return None
+
+
+def normalize_thinking(
+    body: dict[str, Any],
+    provider_model_id: str | None,
+    *,
+    request_id: str = "",
+) -> dict[str, Any]:
+    """Return `body` with `thinking` adjusted to what `provider_model_id` accepts.
+
+    Mutates and returns the same dict (callers build a throwaway body dict).
+    Never raises: any unexpected shape is passed through untouched.
+    """
+    try:
+        thinking = body.get("thinking")
+        if not isinstance(thinking, dict):
+            return body
+
+        t_type = thinking.get("type")
+        if t_type not in ("enabled", "adaptive"):
+            return body
+
+        family = _family(provider_model_id)
+        if family is None:
+            return body
+
+        if family == "adaptive" and t_type == "enabled":
+            new_thinking: dict[str, Any] = {"type": "adaptive"}
+            if "display" in thinking:
+                new_thinking["display"] = thinking["display"]
+            body["thinking"] = new_thinking
+            logger.info(
+                "thinking_normalized",
+                request_id=request_id,
+                provider_model_id=provider_model_id,
+                direction="enabled_to_adaptive",
+                dropped_budget_tokens=thinking.get("budget_tokens"),
+            )
+            return body
+
+        if family == "legacy" and t_type == "adaptive":
+            max_tokens = body.get("max_tokens")
+            budget = _DEFAULT_BUDGET_TOKENS
+            if isinstance(max_tokens, int):
+                budget = min(budget, max_tokens - 1)
+            if budget < _MIN_BUDGET_TOKENS:
+                body.pop("thinking", None)
+                body.pop("output_config", None)
+                logger.info(
+                    "thinking_normalized",
+                    request_id=request_id,
+                    provider_model_id=provider_model_id,
+                    direction="adaptive_dropped_no_budget_room",
+                    max_tokens=max_tokens,
+                )
+                return body
+            new_thinking = {"type": "enabled", "budget_tokens": budget}
+            if "display" in thinking:
+                new_thinking["display"] = thinking["display"]
+            body["thinking"] = new_thinking
+            had_output_config = "output_config" in body
+            body.pop("output_config", None)
+            logger.info(
+                "thinking_normalized",
+                request_id=request_id,
+                provider_model_id=provider_model_id,
+                direction="adaptive_to_enabled",
+                budget_tokens=budget,
+                dropped_output_config=had_output_config,
+            )
+            return body
+
+        return body
+    except Exception:
+        logger.warning(
+            "thinking_normalize_failed",
+            request_id=request_id,
+            provider_model_id=provider_model_id,
+            exc_info=True,
+        )
+        return body

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/services/tool_filter.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/services/tool_filter.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Filter unsupported tool types before sending to Bedrock/Mantle.
+
+Bedrock and Mantle do not support Anthropic's native built-in tool types
+(web_search_20250305, code_execution_20250522, etc.) — they exist only on
+Anthropic's direct API. When clients include these in the request body,
+the backend returns 400: "tool type '...' is not supported for this model"
+
+Web search is handled via the server-side loop (web_search_loop.py) or
+AgentCore MCP; the native tool definitions are safely stripped here.
+
+This filter runs on the body builder AFTER allowed-fields filtering and
+BEFORE sending to the adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Tool type prefixes that Bedrock/Mantle do not support.
+_UNSUPPORTED_TOOL_PREFIXES = (
+    "web_search_",
+    "code_execution_",
+    "text_editor_",
+    "computer_",
+)
+
+
+def strip_unsupported_tools(body: dict[str, Any], *, request_id: str = "") -> dict[str, Any]:
+    """Remove tool definitions that Bedrock/Mantle cannot process.
+
+    Standard function tools (type="function" or type="custom" or no type) are
+    kept. Only Anthropic-native built-in tool types (web_search_*, etc.) are
+    stripped. If all tools are stripped, the tools field itself is removed.
+
+    Never raises — unsupported shapes pass through unchanged.
+    """
+    try:
+        tools = body.get("tools")
+        if not isinstance(tools, list) or not tools:
+            return body
+
+        kept = []
+        stripped = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                kept.append(tool)
+                continue
+            t_type = tool.get("type", "")
+            if isinstance(t_type, str) and t_type.startswith(_UNSUPPORTED_TOOL_PREFIXES):
+                stripped.append(t_type)
+            else:
+                kept.append(tool)
+
+        if stripped:
+            logger.info(
+                "tools_stripped",
+                request_id=request_id,
+                stripped_types=stripped,
+                kept_count=len(kept),
+            )
+            if kept:
+                body["tools"] = kept
+            else:
+                body.pop("tools", None)
+                body.pop("tool_choice", None)
+
+        return body
+    except Exception:
+        logger.warning("tool_filter_failed", request_id=request_id, exc_info=True)
+        return body

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/services/web_search_loop.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/services/web_search_loop.py
@@ -134,6 +134,34 @@ def _client_declares_web_search(body: dict) -> bool:
     return False
 
 
+# Anthropic/OpenAI NATIVE server-side web_search tools carry a `type` naming the
+# server tool (Messages: "web_search_20250305"; Responses: "web_search_preview").
+# Bedrock/Mantle reject these ("tool type ... is not supported for this model").
+# We STRIP them and fulfill the intent with our own injected tool + search loop.
+# A genuinely custom client tool merely NAMED web_search has no such type and is
+# left alone (F-7). Clients like Claude Code CLI attach the native tool by default.
+def _is_native_web_search(tool: dict) -> bool:
+    if not isinstance(tool, dict):
+        return False
+    t = tool.get("type")
+    return isinstance(t, str) and t.startswith("web_search")
+
+
+def _strip_native_web_search(body: dict) -> dict:
+    tools = body.get("tools")
+    if not isinstance(tools, list):
+        return body
+    filtered = [t for t in tools if not _is_native_web_search(t)]
+    if len(filtered) == len(tools):
+        return body  # unchanged — no native tool present
+    out = dict(body)
+    if filtered:
+        out["tools"] = filtered
+    else:
+        out.pop("tools", None)
+    return out
+
+
 # ── usage merge ───────────────────────────────────────────────────────────────
 def _merge_usage(acc: TokenUsage, turn: TokenUsage) -> TokenUsage:
     """Sum usage across turns. reasoning_tokens stays a submetric (already inside
@@ -263,14 +291,20 @@ async def _anthropic_stream(
                                            "id": block.get("id"), "name": block.get("name")}
                         ev2 = dict(ev); ev2["index"] = gi
                         yield _sse("content_block_start", ev2)
+                    elif btype in ("thinking", "redacted_thinking"):
+                        # Buffer thinking for the INTERNAL conversation (the next model turn's
+                        # same-model replay needs it), but do NOT emit it to the client stream
+                        # and do NOT advance global_index. Stitching merges N turns into one
+                        # envelope; a thinking block replayed inside a stitched assistant message
+                        # is rejected by Bedrock ("thinking blocks ... cannot be modified").
+                        thinking_buf[idx] = {"kind": btype, "thinking": "", "signature": "",
+                                             "data": block.get("data")}
                     else:
                         gi = global_index
                         global_index += 1
                         local_to_global[idx] = gi
                         if btype == "text":
                             text_buf[idx] = ""
-                        elif btype in ("thinking", "redacted_thinking"):
-                            thinking_buf[idx] = {"thinking": "", "signature": "", "data": block.get("data")}
                         ev2 = dict(ev); ev2["index"] = gi
                         yield _sse("content_block_start", ev2)
 
@@ -289,12 +323,15 @@ async def _anthropic_stream(
                         ev2 = dict(ev); ev2["index"] = gi
                         yield _sse("content_block_delta", ev2)
                         continue
+                    if idx in thinking_buf:
+                        # Accumulate thinking/signature internally; never emit to client.
+                        if dtype == "thinking_delta":
+                            thinking_buf[idx]["thinking"] += delta.get("thinking", "") or ""
+                        elif dtype == "signature_delta":
+                            thinking_buf[idx]["signature"] += delta.get("signature", "") or ""
+                        continue
                     if dtype == "text_delta" and idx in text_buf:
                         text_buf[idx] += delta.get("text", "") or ""
-                    elif dtype == "thinking_delta" and idx in thinking_buf:
-                        thinking_buf[idx]["thinking"] += delta.get("thinking", "") or ""
-                    elif dtype == "signature_delta" and idx in thinking_buf:
-                        thinking_buf[idx]["signature"] += delta.get("signature", "") or ""
                     gi = local_to_global.get(idx, idx)
                     ev2 = dict(ev); ev2["index"] = gi
                     yield _sse("content_block_delta", ev2)
@@ -325,14 +362,21 @@ async def _anthropic_stream(
                         ev2 = dict(ev); ev2["index"] = gi
                         yield _sse("content_block_stop", ev2)
                         continue
+                    if idx in thinking_buf:
+                        # Keep the thinking block in the INTERNAL conversation so the next
+                        # model turn's same-model replay is valid; do NOT emit its stop to
+                        # the client (start/delta were already suppressed above).
+                        tb = thinking_buf[idx]
+                        if tb.get("kind") == "redacted_thinking":
+                            blk = {"type": "redacted_thinking", "data": tb.get("data")}
+                        else:
+                            blk = {"type": "thinking", "thinking": tb["thinking"]}
+                            if tb["signature"]:
+                                blk["signature"] = tb["signature"]
+                        assistant_content.append(blk)
+                        continue  # suppress from client
                     if idx in text_buf:
                         assistant_content.append({"type": "text", "text": text_buf[idx]})
-                    elif idx in thinking_buf:
-                        tb = thinking_buf[idx]
-                        blk = {"type": "thinking", "thinking": tb["thinking"]}
-                        if tb["signature"]:
-                            blk["signature"] = tb["signature"]
-                        assistant_content.append(blk)
                     gi = local_to_global.get(idx, idx)
                     ev2 = dict(ev); ev2["index"] = gi
                     yield _sse("content_block_stop", ev2)
@@ -498,6 +542,15 @@ async def _anthropic_nonstream(
         # client sees the full accounting; reasoning stays a submetric.
         final_body["usage"]["input_tokens"] = merged.input_tokens
         final_body["usage"]["output_tokens"] = merged.output_tokens
+    # Strip thinking/redacted_thinking from the CLIENT-returned body: the client replays
+    # this (possibly stitched) assistant message on its next turn, and Bedrock rejects a
+    # modified thinking block. Prior-turn thinking may be omitted on a new user turn, so
+    # this is safe. (Mirrors the streaming path's client-side suppression.)
+    if final_status == 200 and isinstance(final_body.get("content"), list):
+        final_body["content"] = [
+            b for b in final_body["content"]
+            if not (isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking"))
+        ]
     return JSONResponse(status_code=final_status, content=final_body)
 
 
@@ -873,6 +926,12 @@ async def run_web_search_loop(
     if that fails, it degrades to a plain pass-through of the original request (no tool).
     """
     deadline = time.monotonic() + total_deadline_sec
+
+    # Strip Anthropic/OpenAI NATIVE web_search tool(s) up front: Bedrock/Mantle reject
+    # them, and we fulfill the intent via our own loop. Doing it here (before F-7) means
+    # a native-only request no longer trips _client_declares_web_search, so the loop runs;
+    # a genuine CUSTOM web_search tool (no native type) survives and is still respected.
+    initial_req_data = _strip_native_web_search(initial_req_data)
 
     # streaming.py sse helpers now call on_usage(usage, first_token_time) (2-arg TTFT
     # contract). The web-search loop's on_usage is 1-arg (multi-turn aggregate — per-turn

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_thinking_normalizer.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_thinking_normalizer.py
@@ -1,0 +1,149 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Unit tests for per-model `thinking` normalization.
+
+Ground truth measured against Tokyo Mantle on 2026-08-06:
+
+    model                       thinking:{enabled}  thinking:{adaptive}  omitted
+    anthropic.claude-opus-4-8   400                 200                  200
+    anthropic.claude-opus-4-7   400                 200                  200
+    anthropic.claude-haiku-4-5  200                 400                  200
+"""
+
+import pytest
+
+from app.services.thinking_normalizer import normalize_thinking
+
+OPUS_48 = "anthropic.claude-opus-4-8"
+OPUS_47 = "anthropic.claude-opus-4-7"
+HAIKU_45 = "anthropic.claude-haiku-4-5"
+
+
+def _body(**kw):
+    b = {"model": "x", "max_tokens": 2048, "messages": [{"role": "user", "content": "hi"}]}
+    b.update(kw)
+    return b
+
+
+@pytest.mark.parametrize("model_id", [OPUS_47, OPUS_48])
+def test_enabled_converted_to_adaptive(model_id):
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 1024}), model_id
+    )
+    assert b["thinking"] == {"type": "adaptive"}
+
+
+def test_enabled_to_adaptive_drops_budget_tokens():
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 32000}), OPUS_48
+    )
+    assert "budget_tokens" not in b["thinking"]
+
+
+def test_enabled_to_adaptive_preserves_display():
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 1024, "display": "summarized"}),
+        OPUS_48,
+    )
+    assert b["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+
+def test_adaptive_untouched_on_adaptive_family():
+    b = normalize_thinking(_body(thinking={"type": "adaptive"}), OPUS_48)
+    assert b["thinking"] == {"type": "adaptive"}
+
+
+def test_output_config_kept_on_adaptive_family():
+    b = normalize_thinking(
+        _body(thinking={"type": "adaptive"}, output_config={"effort": "high"}), OPUS_48
+    )
+    assert b["output_config"] == {"effort": "high"}
+
+
+def test_adaptive_converted_to_enabled():
+    b = normalize_thinking(_body(thinking={"type": "adaptive"}), HAIKU_45)
+    assert b["thinking"]["type"] == "enabled"
+    assert b["thinking"]["budget_tokens"] >= 1024
+
+
+def test_adaptive_to_enabled_strips_output_config():
+    b = normalize_thinking(
+        _body(thinking={"type": "adaptive"}, output_config={"effort": "high"}), HAIKU_45
+    )
+    assert "output_config" not in b
+
+
+def test_budget_stays_below_max_tokens():
+    b = normalize_thinking(
+        _body(max_tokens=2000, thinking={"type": "adaptive"}), HAIKU_45
+    )
+    assert b["thinking"]["budget_tokens"] < 2000
+
+
+def test_thinking_dropped_when_max_tokens_too_small():
+    b = normalize_thinking(_body(max_tokens=64, thinking={"type": "adaptive"}), HAIKU_45)
+    assert "thinking" not in b
+    assert "output_config" not in b
+
+
+def test_enabled_untouched_on_legacy_family():
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 1024}), HAIKU_45
+    )
+    assert b["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+
+
+def test_disabled_never_touched():
+    for model_id in (OPUS_48, HAIKU_45):
+        b = normalize_thinking(_body(thinking={"type": "disabled"}), model_id)
+        assert b["thinking"] == {"type": "disabled"}
+
+
+def test_no_thinking_field_is_noop():
+    b = normalize_thinking(_body(), OPUS_48)
+    assert "thinking" not in b
+
+
+def test_unknown_model_left_untouched():
+    original = {"type": "enabled", "budget_tokens": 1024}
+    b = normalize_thinking(_body(thinking=dict(original)), "anthropic.some-future-model")
+    assert b["thinking"] == original
+
+
+def test_none_model_id_left_untouched():
+    original = {"type": "enabled", "budget_tokens": 1024}
+    b = normalize_thinking(_body(thinking=dict(original)), None)
+    assert b["thinking"] == original
+
+
+def test_geo_prefixed_model_id_resolves():
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 1024}),
+        "us.anthropic.claude-opus-4-8",
+    )
+    assert b["thinking"] == {"type": "adaptive"}
+
+
+def test_versioned_haiku_id_resolves():
+    b = normalize_thinking(
+        _body(thinking={"type": "adaptive"}), "anthropic.claude-haiku-4-5-20251001-v1:0"
+    )
+    assert b["thinking"]["type"] == "enabled"
+
+
+def test_malformed_thinking_does_not_raise():
+    for bad in ("enabled", 42, [], None):
+        b = normalize_thinking(_body(thinking=bad), OPUS_48)
+        assert b["thinking"] == bad
+
+
+def test_other_fields_preserved():
+    b = normalize_thinking(
+        _body(thinking={"type": "enabled", "budget_tokens": 1024}, system="sys",
+              tools=[{"name": "t", "input_schema": {}}]),
+        OPUS_48,
+    )
+    assert b["system"] == "sys"
+    assert b["tools"] == [{"name": "t", "input_schema": {}}]
+    assert b["messages"] == [{"role": "user", "content": "hi"}]

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_tool_filter.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_tool_filter.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for strip_unsupported_tools."""
+
+from app.services.tool_filter import strip_unsupported_tools
+
+
+def test_web_search_tool_stripped():
+    body = {
+        "model": "anthropic.claude-sonnet-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+    }
+    result = strip_unsupported_tools(body, request_id="test-1")
+    assert "tools" not in result
+
+
+def test_function_tools_kept():
+    body = {
+        "model": "anthropic.claude-opus-4-8",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {"type": "function", "name": "get_weather", "input_schema": {}},
+            {"type": "custom", "name": "my_tool"},
+        ],
+    }
+    result = strip_unsupported_tools(body, request_id="test-2")
+    assert len(result["tools"]) == 2
+
+
+def test_mixed_tools_only_unsupported_stripped():
+    body = {
+        "model": "anthropic.claude-opus-4-8",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"},
+            {"type": "function", "name": "get_weather", "input_schema": {}},
+        ],
+        "tool_choice": {"type": "auto"},
+    }
+    result = strip_unsupported_tools(body, request_id="test-3")
+    assert len(result["tools"]) == 1
+    assert result["tools"][0]["name"] == "get_weather"
+    assert "tool_choice" in result
+
+
+def test_all_tools_stripped_removes_tool_choice():
+    body = {
+        "model": "anthropic.claude-opus-4-8",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+        "tool_choice": {"type": "auto"},
+    }
+    result = strip_unsupported_tools(body, request_id="test-4")
+    assert "tools" not in result
+    assert "tool_choice" not in result
+
+
+def test_code_execution_tool_stripped():
+    body = {
+        "tools": [{"type": "code_execution_20250522", "name": "code_exec"}],
+    }
+    result = strip_unsupported_tools(body, request_id="test-5")
+    assert "tools" not in result
+
+
+def test_computer_tool_stripped():
+    body = {
+        "tools": [{"type": "computer_20250124", "name": "computer"}],
+    }
+    result = strip_unsupported_tools(body, request_id="test-6")
+    assert "tools" not in result
+
+
+def test_text_editor_tool_stripped():
+    body = {
+        "tools": [{"type": "text_editor_20250124", "name": "text_editor"}],
+    }
+    result = strip_unsupported_tools(body, request_id="test-7")
+    assert "tools" not in result
+
+
+def test_no_tools_field_is_noop():
+    body = {"model": "anthropic.claude-opus-4-8", "messages": []}
+    result = strip_unsupported_tools(body, request_id="test-8")
+    assert "tools" not in result
+
+
+def test_empty_tools_is_noop():
+    body = {"tools": []}
+    result = strip_unsupported_tools(body, request_id="test-9")
+    assert result["tools"] == []
+
+
+def test_malformed_tool_does_not_raise():
+    body = {"tools": [None, 123, "bad"]}
+    result = strip_unsupported_tools(body, request_id="test-10")
+    assert len(result["tools"]) == 3


### PR DESCRIPTION
## Summary

Fixes three latent bugs in `gateway-proxy` that surface when clients use extended thinking or native web search tools with Bedrock/Mantle.

### 1. Native `web_search` tool strip

Claude Code CLI attaches Anthropic's native server-side web search tool (`type=web_search_20250305`) to requests by default. Bedrock rejects that type, but the F-7 gate (`_client_declares_web_search`) matches on tool **name** only. The request is misjudged as "client owns web_search", the loop is skipped, and `ValidationException` results.

**Fix:** `_strip_native_web_search()` removes typed native tools before F-7, letting the server-side loop fulfill the intent. Genuine custom tools (no `type` field) are preserved.

### 2. Thinking block sealing

Stitching merges N search turns into a single assistant message. Bedrock rejects replayed thinking blocks inside it (`"thinking blocks ... cannot be modified"`).

**Fix:** Buffer thinking blocks for internal conversation only; suppress from client stream and non-streaming response body. Prior-turn thinking may be omitted on the next user turn, so this is safe.

### 3. Per-model thinking normalizer (new module)

Opus 4.7+ requires `thinking:{type:"adaptive"}` and rejects the legacy `enabled` form. Haiku 4.5 is the opposite. The gateway is the only layer that knows the target model, so it normalizes here.

**Fix:** `thinking_normalizer.py` converts between forms per model family. Unknown models pass through untouched (fail-open).

### 4. General tool filter (new module)

`tool_filter.py` strips all Anthropic-native built-in tool types (`web_search_*`, `code_execution_*`, `text_editor_*`, `computer_*`) that Bedrock/Mantle reject. Broader defense than #40's web-search-only strip.

## Relation to #40

This PR extends #40's web_search_loop fixes with the thinking seal (streaming + non-streaming) and adds the two new modules (tool_filter, thinking_normalizer) that defend additional failure modes.

## Test plan

- [x] `test_tool_filter.py` — 10 unit tests
- [x] `test_thinking_normalizer.py` — 19 unit tests (parametrized across model families)
- [x] `test_web_search_loop.py` — 17 existing tests pass (no regression)
- [x] Full gateway-proxy unit suite: **316 tests pass**
- [ ] E2E: Claude Code CLI web search → no `ValidationException`
- [ ] E2E: Extended thinking + multi-turn search → client stream has no thinking blocks
- [ ] E2E: Haiku 4.5 with adaptive thinking request → normalized to enabled form