### PR TITLE
fix(awsome-ai-gateway): unblock model registration + GPT-5.6 aliases, OIDC setup, concurrency fixes

### DIFF
--- a/projects/awsome-ai-gateway/.gitignore
+++ b/projects/awsome-ai-gateway/.gitignore
@@ -71,4 +71,7 @@ values.local.yaml
 
 # OMC orchestration work artifacts (inventories, workflow scripts, session state) — not deliverable
 .omc/
-SECURITY-FINDINGS.md
+
+# Security scan output — reviewer-only, may embed live resource identifiers
+*scan-report*.json
+SECURITY-FINDINGS*.md

--- a/projects/awsome-ai-gateway/admin-api/src/app/core/oidc_verifier.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/core/oidc_verifier.py
@@ -13,14 +13,16 @@ Design notes
 - ``kid`` 매칭으로 정확한 키 선택 → key rotation 안전.
 - jose 의 ``jwt.decode`` 가 sig + exp + nbf + iat + aud + iss 를 모두 검증.
 - ``RS256`` 만 허용 (alg=none, HS256 차단).
+- JWKS fetch is serialized with ``asyncio.Lock`` — holding a blocking lock across
+  an ``await`` stalls the single-threaded event loop forever (see regression #51).
 
 This class is **read-only** w.r.t. database. User/team provisioning happens in
 ``app.services.oidc_service``.
 """
 from __future__ import annotations
 
+import asyncio
 import time
-from threading import Lock
 
 import httpx
 import structlog
@@ -40,8 +42,9 @@ class OIDCConfigError(Exception):
 class OIDCVerifier:
     """OIDC JWT verifier — issuer discovery + JWKS cache + signature/claim 검증.
 
-    Thread-safe (httpx.Client 재사용). 멀티 worker 환경에서 worker 별 1개 인스턴스.
-    Async 호출은 ``verify_async`` 를 사용; sync 컨텍스트면 ``verify``.
+    One instance per worker in a multi-worker deployment (httpx.AsyncClient is reused).
+    Concurrent JWKS fetches are collapsed into one by ``asyncio.Lock`` — the instance
+    must only be used inside the event loop that owns it, never shared across threads.
     """
 
     _ALLOWED_ALGS = ("RS256", "RS384", "RS512")
@@ -82,7 +85,11 @@ class OIDCVerifier:
         self._jwks_uri: str | None = None
         self._jwks_keys: dict[str, dict] = {}  # kid -> JWK dict
         self._jwks_fetched_at: float = 0.0
-        self._lock = Lock()
+        # asyncio.Lock (NOT threading.Lock): _ensure_jwks_async awaits while holding
+        # the lock. With a blocking lock the second request parks the OS thread, so
+        # the event loop itself stops — it cannot even read the JWKS response, and
+        # there is no recovery.
+        self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Discovery + JWKS
@@ -153,7 +160,7 @@ class OIDCVerifier:
         now = time.monotonic()
         if not force and self._jwks_keys and (now - self._jwks_fetched_at) < self._jwks_ttl:
             return
-        with self._lock:
+        async with self._lock:
             # 이중 체크 — lock 진입 사이 다른 호출이 갱신했을 수 있음
             now = time.monotonic()
             if not force and self._jwks_keys and (now - self._jwks_fetched_at) < self._jwks_ttl:

--- a/projects/awsome-ai-gateway/admin-api/src/app/repositories/_locks.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/repositories/_locks.py
@@ -1,0 +1,48 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+"""Transaction-scoped advisory locks for deactivate-then-insert upserts.
+
+Why this exists
+---------------
+``budget_configs`` / ``rate_limit_configs`` are versioned tables: an upsert sets the previous
+row's ``is_active=false`` and inserts a new active row. Two concurrent upserts for the same
+logical key (an admin double-click, an ALB retry, two uvicorn workers) both run their
+deactivate-UPDATE against a snapshot that predates the other's commit, then both INSERT — leaving
+**two** ``is_active=true`` rows. Every subsequent read uses ``scalar_one_or_none()``, so it raises
+``MultipleResultsFound`` → HTTP 500, permanently, for that scope.
+
+Why not ``SELECT ... FOR UPDATE``
+---------------------------------
+Measured on PostgreSQL 16: a row lock is *sufficient only when a row already exists*. On the first
+write for a key there is no row to lock, so both transactions proceed and duplicate. Row locks
+cannot provide mutual exclusion over a key that does not exist yet — and "set a budget for a team
+that has none" is the common case.
+
+``pg_advisory_xact_lock`` locks the **logical key** instead, so it works whether or not a row
+exists. Transaction scope matters: the lock is released on COMMIT/ROLLBACK, leaving no session
+state behind, which keeps it safe under connection pooling and RDS Proxy (a session-scoped
+``pg_advisory_lock`` would leak into whoever reuses the connection).
+
+A partial UNIQUE index (see migration ``0024``) remains the backstop for any writer that forgets
+to take the lock.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# md5 -> bit(64) -> bigint. Deliberately not hashtext(): that function is internal and its hash
+# is not guaranteed stable across major PostgreSQL versions.
+_ADVISORY_LOCK_SQL = text("SELECT pg_advisory_xact_lock(('x' || md5(:lock_key))::bit(64)::bigint)")
+
+
+async def advisory_xact_lock(session: AsyncSession, *parts: object) -> None:
+    """Serialize the current transaction against others sharing the same logical key.
+
+    Blocks until the holder commits or rolls back; released automatically at transaction end.
+    ``parts`` are joined into the key, so callers must include every column that distinguishes
+    one active row from another (e.g. scope, scope_id, client) — otherwise unrelated writes
+    serialize against each other and admin throughput suffers.
+    """
+    key = ":".join("" if p is None else str(p) for p in parts)
+    await session.execute(_ADVISORY_LOCK_SQL, {"lock_key": key})

--- a/projects/awsome-ai-gateway/admin-api/src/app/repositories/budget_repository.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/repositories/budget_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import BudgetConfig, BudgetScope, BudgetUsage, DowngradePolicy
+from app.repositories._locks import advisory_xact_lock
 
 
 class BudgetRepository:
@@ -16,6 +17,13 @@ class BudgetRepository:
         self._session = session
 
     async def upsert_config(self, config: BudgetConfig) -> BudgetConfig:
+        # Serialize concurrent upserts of the same logical key. Without this, two overlapping
+        # writes each deactivate-then-insert and leave two is_active=true rows behind, after
+        # which get_active_config() raises MultipleResultsFound forever (regression #52).
+        # The lock key must match the predicate below exactly, client included.
+        await advisory_xact_lock(
+            self._session, "budget_configs", config.scope.value, config.scope_id, config.client
+        )
         # Deactivate existing for same scope+scope_id+(client if given)
         stmt = update(BudgetConfig).where(
             BudgetConfig.scope == config.scope,

--- a/projects/awsome-ai-gateway/admin-api/src/app/repositories/model_repository.py
+++ b/projects/awsome-ai-gateway/admin-api/src/app/repositories/model_repository.py
@@ -16,6 +16,7 @@ from app.models.model import (
     RateLimitScope,
     TeamAllowedModel,
 )
+from app.repositories._locks import advisory_xact_lock
 
 
 class ModelRepository:
@@ -150,6 +151,16 @@ class RateLimitConfigRepository:
         self._session = session
 
     async def upsert(self, config: RateLimitConfig) -> RateLimitConfig:
+        # Serialize concurrent upserts of the same logical key, or two overlapping writes each
+        # deactivate-then-insert and leave two is_active=true rows behind — after which
+        # get_active() raises MultipleResultsFound forever (regression #53).
+        #
+        # The key is (scope, scope_id) WITHOUT model_alias, matching the predicate below: this
+        # upsert is deliberately alias-blind, so at most one active row per scope exists. Adding
+        # model_alias to the key would let two concurrent writes for different aliases race.
+        await advisory_xact_lock(
+            self._session, "rate_limit_configs", config.scope.value, config.scope_id
+        )
         stmt = (
             update(RateLimitConfig)
             .where(

--- a/projects/awsome-ai-gateway/admin-api/tests/regression/test_critical_oidc_verifier_deadlock.py
+++ b/projects/awsome-ai-gateway/admin-api/tests/regression/test_critical_oidc_verifier_deadlock.py
@@ -1,0 +1,190 @@
+# Copyright 2026 © Amazon.com and Affiliates
+"""Regression: #51 — OIDC verifier must not hold a blocking lock across `await`.
+
+Bug: ``_ensure_jwks_async`` held a ``threading.Lock`` while awaiting the JWKS HTTP fetch. On a
+single-threaded event loop the second concurrent request called ``lock.acquire()``, which parks
+the OS **thread** rather than just the task — so the loop could never resume the first task to
+finish its fetch. The whole admin-api worker stopped answering, and it could not recover on its
+own: reading the JWKS response would itself require the loop. In production this presented as a
+pod that had to be restarted, triggered by nothing more exotic than a cold start plus two
+concurrent admin requests.
+
+Fix: ``asyncio.Lock`` + ``async with``. Both halves are required — ``asyncio.Lock`` does not
+support the synchronous ``with`` statement, so swapping only the lock type raises TypeError
+*before* the fetch. That hides the deadlock symptom while breaking every OIDC login, which is why
+this file asserts the fetch still happens rather than merely asserting "no deadlock".
+
+Observation design: a wedged event loop cannot report on itself, so the loop runs in a worker
+thread and a heartbeat counter is sampled from the test thread.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import inspect
+import json
+import threading
+import time
+
+import httpx
+import pytest
+
+from app.core.oidc_verifier import OIDCVerifier
+
+ISSUER = "https://example-idp.test/realm"
+
+
+def _b64(d: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+
+
+# verify_async rejects malformed tokens before any JWKS fetch, so the token has to be shaped like
+# a real JWT to reach the locked section at all.
+TOKEN = f'{_b64({"alg": "RS256", "kid": "k1", "typ": "JWT"})}.{_b64({"iss": ISSUER, "sub": "u1"})}.sig'
+
+
+@pytest.mark.unit
+def test_lock_is_asyncio_not_threading():
+    """The lock type is the fix. A ``threading.Lock`` here is the bug, by construction."""
+    v = OIDCVerifier(issuer_url=ISSUER, audience=None)
+    assert isinstance(v._lock, asyncio.Lock), type(v._lock)
+    assert not isinstance(v._lock, type(threading.Lock()))
+
+
+@pytest.mark.unit
+def test_lock_is_acquired_with_async_with():
+    """`asyncio.Lock` has no ``__enter__``, so a plain ``with self._lock`` would raise TypeError
+    at runtime — before the JWKS fetch, making a broken verifier look healthy. Assert the source
+    uses ``async with`` so the two halves of the fix can never drift apart."""
+    src = inspect.getsource(OIDCVerifier._ensure_jwks_async)
+    assert "async with self._lock" in src
+    assert not any(
+        line.strip().startswith("with self._lock") for line in src.splitlines()
+    ), "synchronous `with` on an asyncio.Lock raises TypeError"
+
+
+class _SlowIdP:
+    """Real ASGI IdP whose JWKS response is held open until released — what a cold fetch against
+    a remote IdP looks like from the event loop's point of view."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()   # threading: set from the test thread
+        self.jwks_hits = 0
+
+    async def __call__(self, scope, receive, send):
+        path = scope["path"]
+        if path.endswith("/.well-known/openid-configuration"):
+            # The verifier requires discovery.issuer to match the configured issuer exactly.
+            body = (b'{"issuer": "' + ISSUER.encode() + b'",'
+                    b' "jwks_uri": "' + ISSUER.encode() + b'/keys"}')
+        elif path.endswith("/keys"):
+            self.jwks_hits += 1
+            while not self.release.is_set():
+                await asyncio.sleep(0.01)      # yield to the loop while waiting
+            body = (b'{"keys": [{"kid": "k1", "use": "sig", "kty": "RSA", "alg": "RS256",'
+                    b' "n": "AQAB", "e": "AQAB"}]}')
+        else:
+            body = b"{}"
+        await send({"type": "http.response.start", "status": 200,
+                    "headers": [(b"content-type", b"application/json")]})
+        await send({"type": "http.response.body", "body": body})
+
+
+class _LoopHarness:
+    """Runs an event loop in a worker thread, exposing a heartbeat the test thread can sample.
+
+    The heartbeat advances only while the loop is scheduling tasks. If the loop's thread is parked
+    inside a blocking ``lock.acquire()``, it freezes — the "pod stopped answering" symptom.
+    """
+
+    def __init__(self, verifier: OIDCVerifier, idp: _SlowIdP) -> None:
+        self.verifier = verifier
+        self.idp = idp
+        self.heartbeat = 0
+        self.ready = threading.Event()
+        self._stop = False
+        self.thread = threading.Thread(target=lambda: asyncio.run(self._main()), daemon=True)
+
+    async def _heart(self) -> None:
+        while not self._stop:
+            await asyncio.sleep(0.02)
+            self.heartbeat += 1
+
+    async def _verify(self, client) -> None:
+        try:
+            await self.verifier.verify_async(TOKEN, client)
+        except Exception:
+            pass   # liveness is the measurement here, not the verification outcome
+
+    async def _main(self) -> None:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=self.idp)) as client:
+            hb = asyncio.create_task(self._heart())
+            self.ready.set()
+            a = asyncio.create_task(self._verify(client))
+            await asyncio.sleep(0.15)          # let A get inside the lock, awaiting JWKS
+            b = asyncio.create_task(self._verify(client))
+            await asyncio.gather(a, b, return_exceptions=True)
+            self._stop = True
+            hb.cancel()
+            await asyncio.gather(hb, return_exceptions=True)
+
+    def start(self) -> None:
+        self.thread.start()
+        self.ready.wait(10)
+
+
+def _advanced(h: _LoopHarness, seconds: float) -> bool:
+    """True if the loop scheduled anything during the window. A thread that has already exited
+    is reported as advanced=True, since a finished loop is not a wedge."""
+    before = h.heartbeat
+    time.sleep(seconds)
+    if not h.thread.is_alive():
+        return True
+    return h.heartbeat != before
+
+
+@pytest.mark.unit
+def test_loop_stays_responsive_during_concurrent_cold_jwks_fetch():
+    """Two concurrent verifies on a cold verifier must not stall the event loop.
+
+    With the old blocking lock the heartbeat froze here and never resumed, even after the IdP
+    answered.
+    """
+    idp = _SlowIdP()
+    h = _LoopHarness(OIDCVerifier(issuer_url=ISSUER, audience=None), idp)
+    h.start()
+
+    time.sleep(0.8)
+    assert idp.jwks_hits >= 1, "rig failed: the JWKS fetch never started, so nothing was contended"
+
+    responsive = _advanced(h, 0.5)
+
+    idp.release.set()
+    h.thread.join(timeout=15)
+
+    assert responsive, (
+        f"event loop stopped scheduling while a JWKS fetch was in flight "
+        f"(heartbeat stuck at {h.heartbeat}) — a blocking lock is being held across await"
+    )
+    assert not h.thread.is_alive(), "both verifies should have completed once the IdP answered"
+
+
+@pytest.mark.unit
+def test_concurrent_verifies_collapse_into_a_single_jwks_fetch():
+    """The double-check inside the lock must still do its job: two concurrent cold verifies
+    result in exactly one JWKS fetch, not one per request.
+
+    ``jwks_hits == 1`` is also what catches a lock swapped to ``asyncio.Lock`` without changing
+    ``with`` to ``async with`` — that variant raises TypeError before fetching, giving 0 hits.
+    """
+    idp = _SlowIdP()
+    h = _LoopHarness(OIDCVerifier(issuer_url=ISSUER, audience=None), idp)
+    h.start()
+    time.sleep(0.8)
+    idp.release.set()
+    h.thread.join(timeout=15)
+
+    assert idp.jwks_hits == 1, (
+        f"expected the in-lock double-check to collapse two concurrent verifies into one JWKS "
+        f"fetch, got {idp.jwks_hits}"
+    )

--- a/projects/awsome-ai-gateway/admin-api/tests/regression/test_high_duplicate_active_config.py
+++ b/projects/awsome-ai-gateway/admin-api/tests/regression/test_high_duplicate_active_config.py
@@ -1,0 +1,791 @@
+# Copyright 2026 © Amazon.com and Affiliates
+"""Regression: #52 / #53 — versioned config upserts must not leave two is_active=true rows.
+
+Bug: ``BudgetRepository.upsert_config`` and ``RateLimitConfigRepository.upsert`` deactivate the
+current active row and then insert a new one. Two overlapping calls for the same key (admin
+double-click, ALB retry, two uvicorn workers) each ran their deactivate-UPDATE against a snapshot
+predating the other's commit, then both inserted. The read paths use ``scalar_one_or_none()``, so
+from that point on every read of that scope raised ``MultipleResultsFound`` → HTTP 500 — and it
+never healed, because nothing in the product removes the extra row.
+
+Fix, two independent layers:
+  1. ``pg_advisory_xact_lock`` on the logical key in the write path (``app/repositories/_locks.py``),
+     so the second caller *succeeds* — it waits, then correctly supersedes — rather than merely
+     failing safely;
+  2. partial UNIQUE indexes (migration ``0024``, and ``db/init/02_create_tables.sql`` for fresh
+     installs) as the database-level backstop for any writer that skips the lock.
+
+Both regressions share one fix, one migration and one test rig, so they share one file.
+
+Two findings were measured on real PostgreSQL 16 while developing this fix and are asserted below,
+because each is easy to get wrong in a way that still looks correct:
+
+  * ``SELECT ... FOR UPDATE`` is NOT sufficient. It serializes only when a row already exists; on
+    the first write for a key there is nothing to lock, so both transactions insert. Row locks
+    cannot provide mutual exclusion over a key that does not exist yet — and "set a budget for a
+    team that has none" is the common case.
+  * The unique indexes MUST wrap the nullable key columns in ``COALESCE``. NULLs are distinct in a
+    unique index, so a plain index leaves exactly the rows that matter unprotected: the org-wide
+    budget (``client IS NULL``) and the GLOBAL rate limit (``scope_id IS NULL``).
+
+The static assertions run everywhere. The behavioural proofs need real PostgreSQL — MVCC snapshot
+semantics are the thing under test, so a mock or SQLite would prove nothing — and are skipped
+unless ``PROOF_DSN`` is set. They CREATE and DROP the ``auth`` / ``budget`` / ``model`` schemas, so
+they refuse to run against anything but a scratch database (see ``_require_scratch_db``)::
+
+    docker run -d --name pg-proof -p 55432:5432 -e POSTGRES_PASSWORD=proof \\
+        -e POSTGRES_DB=gwproof postgres:16-alpine
+    PROOF_DSN=postgresql+asyncpg://postgres:proof@127.0.0.1:55432/gwproof \\
+        pytest tests/regression/test_high_duplicate_active_config.py
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import re
+import uuid
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.repositories import _locks
+from app.repositories._locks import advisory_xact_lock
+from app.repositories.budget_repository import BudgetRepository
+from app.repositories.model_repository import RateLimitConfigRepository
+
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION = _REPO_ROOT / "db" / "versions" / "0024_unique_active_config_indexes.py"
+_INIT_SQL = _REPO_ROOT / "db" / "init" / "02_create_tables.sql"
+
+PROOF_DSN = os.environ.get("PROOF_DSN")
+_DB = pytest.mark.skipif(not PROOF_DSN, reason="PROOF_DSN not set (needs a real PostgreSQL)")
+
+
+# ===========================================================================
+# Layer 1 — the write path must take the advisory lock, keyed correctly.
+# ===========================================================================
+
+@pytest.mark.unit
+def test_budget_upsert_locks_before_deactivating():
+    src = inspect.getsource(BudgetRepository.upsert_config)
+    assert "advisory_xact_lock" in src, (
+        "upsert_config must serialize on the logical key; without it two concurrent writes each "
+        "insert an active row and every later read of that scope returns 500"
+    )
+    assert src.index("advisory_xact_lock") < src.index("update(BudgetConfig)"), (
+        "the lock must be taken BEFORE the deactivate-UPDATE, or the race window stays open"
+    )
+
+
+@pytest.mark.unit
+def test_budget_lock_key_includes_client():
+    """The lock key must match the UPDATE's predicate exactly. ``client`` is in that predicate
+    (per-app budgets are separate active rows), so it must be in the key: omitting it would
+    serialize unrelated per-app writes, and the key would no longer identify one active row."""
+    src = inspect.getsource(BudgetRepository.upsert_config)
+    lock_call = src[src.index("advisory_xact_lock"):src.index("update(BudgetConfig)")]
+    for part in ("config.scope", "config.scope_id", "config.client"):
+        assert part in lock_call, f"budget lock key must include {part}"
+
+
+@pytest.mark.unit
+def test_rate_limit_upsert_locks_on_a_key_without_model_alias():
+    """``RateLimitConfigRepository.upsert`` is deliberately alias-blind — it deactivates every
+    active row for the scope regardless of model_alias — so the lock key must mirror that.
+    Adding model_alias would let two concurrent writes for different aliases race and duplicate."""
+    src = inspect.getsource(RateLimitConfigRepository.upsert)
+    assert "advisory_xact_lock" in src
+    lock_call = src[src.index("advisory_xact_lock"):src.index("update(RateLimitConfig)")]
+    assert "config.scope" in lock_call and "config.scope_id" in lock_call
+    assert "model_alias" not in lock_call, (
+        "the rate-limit lock key must not include model_alias — the upsert predicate does not"
+    )
+
+
+@pytest.mark.unit
+def test_lock_is_transaction_scoped():
+    """A session-scoped ``pg_advisory_lock`` would survive the transaction and leak into whichever
+    request next borrows that pooled connection (and would pin it under RDS Proxy)."""
+    assert "pg_advisory_xact_lock" in _locks._ADVISORY_LOCK_SQL.text
+    assert not re.search(r"\bpg_advisory_lock\s*\(", _locks._ADVISORY_LOCK_SQL.text)
+
+
+class _RecordingSession:
+    """Captures the bound lock key so key derivation can be tested without a database."""
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+
+    async def execute(self, statement, params=None):  # noqa: ANN001 - test double
+        self.keys.append(params["lock_key"])
+        return None
+
+
+async def _key(*parts: object) -> str:
+    session = _RecordingSession()
+    await advisory_xact_lock(session, *parts)  # type: ignore[arg-type]
+    return session.keys[0]
+
+
+@pytest.mark.unit
+async def test_lock_key_distinguishes_every_part():
+    """Two different logical keys must never collapse onto the same lock, or writes to unrelated
+    scopes would block each other; and the same logical key must always produce the same lock."""
+    team_a, team_b = uuid.uuid4(), uuid.uuid4()
+    assert await _key("budget_configs", "TEAM", team_a, None) == \
+           await _key("budget_configs", "TEAM", team_a, None)
+    assert await _key("budget_configs", "TEAM", team_a, None) != \
+           await _key("budget_configs", "TEAM", team_b, None)
+    assert await _key("budget_configs", "TEAM", team_a, None) != \
+           await _key("budget_configs", "TEAM", team_a, "claude-code")
+    assert await _key("budget_configs", "TEAM", team_a) != \
+           await _key("rate_limit_configs", "TEAM", team_a)
+    # Order-sensitive: a naive key that summed or set-ified the parts would collide here.
+    assert await _key("a", "b") != await _key("b", "a")
+
+
+@pytest.mark.unit
+async def test_lock_key_treats_none_as_absent():
+    """``None`` renders as the empty string. Harmless for the two callers: ``client`` is
+    constrained to NULL or one of the app names (ck_budget_configs_client), so '' never occurs,
+    and ``scope_id`` is a UUID."""
+    assert await _key("t", None) == await _key("t", "")
+
+
+# ===========================================================================
+# Layer 2 — the schema backstop. Both DDL sources must agree.
+# ===========================================================================
+
+@pytest.mark.unit
+def test_migration_0024_is_on_the_chain():
+    assert _MIGRATION.exists(), "migration 0024 is missing"
+    src = _MIGRATION.read_text()
+    assert 'revision = "0024"' in src
+    assert 'down_revision = "0023"' in src, "a wrong down_revision branches the chain"
+
+
+@pytest.mark.unit
+def test_migration_0024_dedupes_before_creating_the_indexes():
+    """CREATE UNIQUE INDEX fails outright if duplicates already exist, which would abort the
+    upgrade on exactly the installations that need it most. The dedupe must come first, and it
+    must demote rather than delete so the history stays auditable."""
+    src = _MIGRATION.read_text()
+    upgrade = src.split("def upgrade")[1]
+    assert upgrade.index("DEDUPE_BUDGET_CONFIGS") < upgrade.index("CREATE UNIQUE INDEX")
+    assert upgrade.index("DEDUPE_RATE_LIMIT_CONFIGS") < upgrade.index("CREATE UNIQUE INDEX")
+    assert "row_number() OVER" in src, "dedupe must keep exactly one row per key"
+    assert "SET is_active = false" in src, "losers must be demoted, not deleted"
+
+
+def _index_ddl(name: str) -> str:
+    """The shipped CREATE statement for one index, taken from db/init/02_create_tables.sql.
+
+    The behavioural proofs below run against this exact text rather than a copy, so the rig cannot
+    drift away from what customers actually install.
+    """
+    src = _INIT_SQL.read_text()
+    match = re.search(rf"CREATE UNIQUE INDEX IF NOT EXISTS {name}\b.*?;", src, re.DOTALL)
+    assert match, f"{name} not found in {_INIT_SQL.name}"
+    return match.group(0).rstrip(";")
+
+
+def _migration_index_ddl(name: str) -> str:
+    """The SQL migration 0024 *emits* for one index.
+
+    Asserting against the raw file text would be wrong: the migration builds the rate-limit index
+    with an f-string, so the sentinel UUID never appears literally in the source. Resolve
+    ``{NIL_UUID}`` from the module's own constant — which also pins the sentinel to the nil UUID,
+    the one value ``gen_random_uuid()`` (v4) can never produce.
+    """
+    src = _MIGRATION.read_text()
+    sentinel = re.search(r'^NIL_UUID = "([0-9a-f-]+)"$', src, re.MULTILINE)
+    assert sentinel, "migration 0024 must define NIL_UUID"
+    assert sentinel.group(1) == NIL_UUID, (
+        f"sentinel drifted to {sentinel.group(1)!r}; a non-nil UUID could collide with a real "
+        f"scope_id and wrongly reject a legitimate row"
+    )
+    # Each index is one op.execute( ... ) call whose closing paren sits at 4-space indent.
+    match = re.search(rf"CREATE UNIQUE INDEX IF NOT EXISTS {name}\b.*?\n    \)", src, re.DOTALL)
+    assert match, f"{name} not created in {_MIGRATION.name}"
+    return match.group(0).replace("{NIL_UUID}", NIL_UUID)
+
+
+def _all_index_ddl(name: str) -> list[tuple[str, str]]:
+    """(source label, emitted DDL) for both places the index is defined."""
+    return [(_INIT_SQL.name, _index_ddl(name)), (_MIGRATION.name, _migration_index_ddl(name))]
+
+
+@pytest.mark.unit
+def test_both_ddl_sources_define_both_indexes():
+    """Fresh installs run db/init; upgrades run migration 0024. A guard that only checked one
+    would let the other rot."""
+    for name in ("uq_budget_configs_active", "uq_rate_limit_configs_active"):
+        for label, ddl in _all_index_ddl(name):
+            assert name in ddl, f"{label}: {name} missing"
+
+
+@pytest.mark.unit
+def test_indexes_coalesce_the_nullable_key_columns():
+    """The NULL trap, in both DDL sources. NULLs are distinct in a unique index, so without
+    COALESCE the org-wide budget row (client IS NULL) and the GLOBAL rate limit (scope_id IS NULL)
+    — the two highest blast-radius rows — are not protected at all."""
+    for label, ddl in _all_index_ddl("uq_budget_configs_active"):
+        assert "COALESCE(client, '')" in ddl, f"{label}: client must be COALESCEd"
+    for label, ddl in _all_index_ddl("uq_rate_limit_configs_active"):
+        assert f"COALESCE(scope_id, '{NIL_UUID}'::uuid)" in ddl, (
+            f"{label}: scope_id must be COALESCEd — GLOBAL scope stores NULL"
+        )
+
+
+@pytest.mark.unit
+def test_dedupe_partitions_match_the_index_keys():
+    """The dedupe must group by exactly what the index makes unique. A mismatch would either
+    leave duplicates behind (index creation then fails, aborting the upgrade) or demote rows the
+    index would have allowed."""
+    src = _MIGRATION.read_text().replace("{NIL_UUID}", NIL_UUID)
+    assert "PARTITION BY scope, scope_id, COALESCE(client, '')" in src
+    assert f"PARTITION BY scope, COALESCE(scope_id, '{NIL_UUID}'::uuid)" in src
+
+
+@pytest.mark.unit
+def test_rate_limit_index_is_not_keyed_on_model_alias():
+    """Mirrors the lock key. Since the upsert deactivates alias-blind, keying the index on
+    model_alias would leave the real duplicate window open while looking protective."""
+    for label, ddl in _all_index_ddl("uq_rate_limit_configs_active"):
+        assert "model_alias" not in ddl, f"{label}: {ddl}"
+
+
+@pytest.mark.unit
+def test_indexes_are_partial_on_is_active():
+    """The indexes must be partial. A full unique index would reject the *second* update to any
+    budget, because the deactivated history rows share the key."""
+    for name in ("uq_budget_configs_active", "uq_rate_limit_configs_active"):
+        for label, ddl in _all_index_ddl(name):
+            assert "WHERE is_active = true" in ddl, f"{label}: {name} must be partial"
+
+
+# ===========================================================================
+# Behavioural proofs — real PostgreSQL, real concurrent transactions.
+# ===========================================================================
+
+_ACTOR = uuid.UUID("00000000-0000-0000-0000-0000000000ff")
+
+# Minimal slice of the asset schema: the two tables under test plus the FK targets they need.
+# Enum members and the client CHECK mirror db/init/02_create_tables.sql; the unique indexes are
+# read from that file verbatim by _index_ddl().
+_BASE_DDL = [
+    "DROP SCHEMA IF EXISTS budget CASCADE",
+    "DROP SCHEMA IF EXISTS model CASCADE",
+    "DROP SCHEMA IF EXISTS auth CASCADE",
+    "CREATE SCHEMA auth",
+    "CREATE SCHEMA budget",
+    "CREATE SCHEMA model",
+    "CREATE TABLE auth.users (id UUID PRIMARY KEY)",
+    "CREATE TYPE budget.budget_scope  AS ENUM ('TEAM', 'USER')",
+    "CREATE TYPE budget.period_type   AS ENUM ('MONTHLY')",
+    "CREATE TYPE budget.budget_policy AS ENUM ('HARD_BLOCK', 'SOFT_WARNING', 'THROTTLE')",
+    "CREATE TYPE model.rate_limit_scope AS ENUM ('USER', 'TEAM', 'GLOBAL')",
+    """
+    CREATE TABLE budget.budget_configs (
+        id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        scope           budget.budget_scope  NOT NULL,
+        scope_id        UUID                 NOT NULL,
+        client          VARCHAR(32)          NULL,
+        max_budget_usd  NUMERIC(12,4)        NOT NULL,
+        period_type     budget.period_type   NOT NULL DEFAULT 'MONTHLY',
+        policy          budget.budget_policy NOT NULL DEFAULT 'HARD_BLOCK',
+        allocated_by    UUID                 NOT NULL REFERENCES auth.users(id),
+        effective_from  DATE                 NOT NULL,
+        is_active       BOOLEAN              NOT NULL DEFAULT true,
+        created_at      TIMESTAMPTZ          NOT NULL DEFAULT now(),
+        CONSTRAINT ck_budget_configs_client
+            CHECK (client IS NULL OR client IN ('claude-code','cowork','codex'))
+    )
+    """,
+    "CREATE TABLE model.model_aliases (alias VARCHAR(128) PRIMARY KEY)",
+    "INSERT INTO model.model_aliases (alias) VALUES ('alias-a'), ('alias-b')",
+    """
+    CREATE TABLE model.rate_limit_configs (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        scope         model.rate_limit_scope NOT NULL,
+        scope_id      UUID,
+        model_alias   VARCHAR(128) REFERENCES model.model_aliases(alias),
+        rpm_limit     INTEGER,
+        tpm_limit     INTEGER,
+        cpm_limit_usd NUMERIC(10,4),
+        cph_limit_usd NUMERIC(10,4),
+        is_active     BOOLEAN      NOT NULL DEFAULT true,
+        created_by    UUID         NOT NULL REFERENCES auth.users(id),
+        created_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+        updated_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+    )
+    """,
+]
+
+
+def _require_scratch_db(dsn: str) -> None:
+    """Refuse to run against anything that is not obviously a throwaway database.
+
+    These fixtures DROP SCHEMA ... CASCADE on auth/budget/model. Pointed at a real gateway database
+    that would destroy every user, budget and model row, so the guard is deliberately blunt: the
+    database name has to say it is scratch.
+    """
+    dbname = dsn.rsplit("/", 1)[-1].split("?")[0].lower()
+    if not any(token in dbname for token in ("proof", "test", "scratch", "tmp")):
+        pytest.fail(
+            f"PROOF_DSN points at database {dbname!r}. These tests DROP the auth/budget/model "
+            f"schemas, so they only run against a scratch database whose name contains "
+            f"'proof', 'test', 'scratch' or 'tmp'."
+        )
+
+
+async def _bootstrap(*, with_indexes: bool):
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models.auth  # noqa: F401 — registers auth.users so the FK targets resolve
+
+    _require_scratch_db(PROOF_DSN)
+    ddl = list(_BASE_DDL)
+    if with_indexes:
+        ddl += [_index_ddl("uq_budget_configs_active"), _index_ddl("uq_rate_limit_configs_active")]
+
+    engine = create_async_engine(PROOF_DSN)
+    async with engine.begin() as conn:
+        for statement in ddl:
+            await conn.execute(text(statement))
+        await conn.execute(text("INSERT INTO auth.users (id) VALUES (:i)"), {"i": _ACTOR})
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+async def sm():
+    """Schema as shipped: advisory lock in the code, unique indexes in the database."""
+    engine, maker = await _bootstrap(with_indexes=True)
+    yield maker
+    await engine.dispose()
+
+
+@pytest.fixture
+async def sm_no_index():
+    """Indexes omitted, so the lock is the only defense — this is what isolates layer 1 and lets
+    the original bug still be reproduced by the adversary repos below."""
+    engine, maker = await _bootstrap(with_indexes=False)
+    yield maker
+    await engine.dispose()
+
+
+def _budget(scope_id: uuid.UUID, amount: str, client: str | None = None):
+    from app.models.budget import BudgetConfig, BudgetPolicy, BudgetScope, PeriodType
+
+    return BudgetConfig(
+        id=uuid.uuid4(), scope=BudgetScope.TEAM, scope_id=scope_id, client=client,
+        max_budget_usd=Decimal(amount), period_type=PeriodType.MONTHLY,
+        policy=BudgetPolicy.HARD_BLOCK, allocated_by=_ACTOR,
+        effective_from=date.today(), is_active=True,
+    )
+
+
+def _rate_limit(scope, scope_id: uuid.UUID | None, rpm: int, model_alias: str | None = None):
+    from app.models.model import RateLimitConfig
+
+    return RateLimitConfig(
+        id=uuid.uuid4(), scope=scope, scope_id=scope_id, model_alias=model_alias,
+        rpm_limit=rpm, is_active=True, created_by=_ACTOR,
+    )
+
+
+# --- Adversaries. Deliberate copies of the pre-fix write paths: with the advisory lock in place
+# --- nothing races, so without these the index layer would never be exercised and a weakened
+# --- index (one that lost its COALESCE, say) would pass unnoticed.
+
+class _LockFreeBudgetRepo(BudgetRepository):
+    async def upsert_config(self, config):
+        from sqlalchemy import update
+
+        from app.models.budget import BudgetConfig
+
+        stmt = update(BudgetConfig).where(
+            BudgetConfig.scope == config.scope,
+            BudgetConfig.scope_id == config.scope_id,
+            BudgetConfig.is_active.is_(True),
+        )
+        if config.client is not None:
+            stmt = stmt.where(BudgetConfig.client == config.client)
+        else:
+            stmt = stmt.where(BudgetConfig.client.is_(None))
+        await self._session.execute(stmt.values(is_active=False))
+        self._session.add(config)
+        await self._session.flush()
+        return config
+
+
+class _ForUpdateBudgetRepo(_LockFreeBudgetRepo):
+    """The tempting alternative: lock the rows we are about to deactivate."""
+
+    async def upsert_config(self, config):
+        from sqlalchemy import select
+
+        from app.models.budget import BudgetConfig
+
+        await self._session.execute(
+            select(BudgetConfig.id)
+            .where(
+                BudgetConfig.scope == config.scope,
+                BudgetConfig.scope_id == config.scope_id,
+                BudgetConfig.is_active.is_(True),
+            )
+            .with_for_update()
+        )
+        return await super().upsert_config(config)
+
+
+class _LockFreeRateLimitRepo(RateLimitConfigRepository):
+    async def upsert(self, config):
+        from sqlalchemy import update
+
+        from app.models.model import RateLimitConfig
+
+        await self._session.execute(
+            update(RateLimitConfig)
+            .where(
+                RateLimitConfig.scope == config.scope,
+                RateLimitConfig.scope_id == config.scope_id,
+                RateLimitConfig.is_active.is_(True),
+            )
+            .values(is_active=False)
+        )
+        self._session.add(config)
+        await self._session.flush()
+        return config
+
+
+async def _budget_upsert(session, cfg, repo=BudgetRepository):
+    return await repo(session).upsert_config(cfg)
+
+
+async def _rl_upsert(session, cfg, repo=RateLimitConfigRepository):
+    return await repo(session).upsert(cfg)
+
+
+async def _race(sm, upsert, cfg_a, cfg_b, *, repo=None) -> list[BaseException]:
+    """Two genuinely overlapping transactions: tx1 does its writes, tx2 starts while tx1 is still
+    open, and only then does tx1 commit. Returns whatever exceptions were raised."""
+    from sqlalchemy import text
+
+    kwargs = {} if repo is None else {"repo": repo}
+
+    async def tx(cfg, started=None, gate=None):
+        async with sm() as session:
+            # Fail loudly instead of hanging the suite if a lock is genuinely stuck.
+            await session.execute(text("SET lock_timeout = '10s'"))
+            await upsert(session, cfg, **kwargs)
+            if started is not None:
+                started.set()
+            if gate is not None:
+                await gate.wait()
+            await session.commit()
+
+    started, gate = asyncio.Event(), asyncio.Event()
+    t1 = asyncio.create_task(tx(cfg_a, started, gate))
+    await asyncio.wait_for(started.wait(), 10)
+    t2 = asyncio.create_task(tx(cfg_b))
+    await asyncio.sleep(0.5)
+    gate.set()
+    results = await asyncio.wait_for(asyncio.gather(t1, t2, return_exceptions=True), 40)
+    return [r for r in results if isinstance(r, BaseException)]
+
+
+async def _scalar(sm, sql: str, **params):
+    from sqlalchemy import text
+
+    async with sm() as session:
+        return (await session.execute(text(sql), params)).scalar_one()
+
+
+_ACTIVE_BUDGETS = (
+    "SELECT count(*) FROM budget.budget_configs "
+    "WHERE scope='TEAM' AND scope_id=:t AND is_active=true"
+)
+_ACTIVE_LIMITS_FOR_TEAM = (
+    "SELECT count(*) FROM model.rate_limit_configs "
+    "WHERE scope='TEAM' AND scope_id=:t AND is_active=true"
+)
+_ACTIVE_GLOBAL_LIMITS = (
+    "SELECT count(*) FROM model.rate_limit_configs "
+    "WHERE scope='GLOBAL' AND scope_id IS NULL AND is_active=true"
+)
+
+
+@_DB
+@pytest.mark.integration
+class TestTheBugIsRealAndForUpdateDoesNotFixIt:
+    """Reproduce #52/#53 with the lock removed, on a schema without the backstop indexes. If these
+    ever stop reproducing, the rig has broken and every test below is vacuous."""
+
+    async def test_unlocked_upserts_leave_two_active_rows(self, sm_no_index):
+        team = uuid.uuid4()
+        errs = await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"),
+                           repo=_LockFreeBudgetRepo)
+        assert not errs, f"the original bug was silent, not an error: {errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_BUDGETS, t=team) == 2
+
+    async def test_duplicate_rows_break_the_read_path_permanently(self, sm_no_index):
+        """The user-visible symptom, and why "it heals itself" was never an option: the corrupted
+        scope keeps raising until someone edits the table by hand."""
+        from sqlalchemy.exc import MultipleResultsFound
+
+        from app.models.budget import BudgetScope
+
+        team = uuid.uuid4()
+        await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"),
+                    repo=_LockFreeBudgetRepo)
+        async with sm_no_index() as session:
+            with pytest.raises(MultipleResultsFound):
+                await BudgetRepository(session).get_active_config(BudgetScope.TEAM, team)
+
+    async def test_select_for_update_does_not_serialize_the_first_write(self, sm_no_index):
+        """DISPROOF of the obvious fix, measured on PostgreSQL 16. With no existing row there is
+        nothing to lock, so FOR UPDATE locks nothing and both transactions insert. This is why the
+        shipped fix locks the logical key instead."""
+        team = uuid.uuid4()
+        errs = await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"),
+                           repo=_ForUpdateBudgetRepo)
+        assert not errs, f"unexpected errors: {errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_BUDGETS, t=team) == 2, (
+            "FOR UPDATE unexpectedly serialized a first write — re-derive the fix before relying "
+            "on the advisory-lock rationale"
+        )
+
+    async def test_select_for_update_does_serialize_when_a_row_exists(self, sm_no_index):
+        """The other half of the measurement, recorded so the disproof above is not overstated:
+        once a row exists, FOR UPDATE is sufficient. tx2 blocks in the SELECT; its subsequent
+        UPDATE is a new statement whose fresh READ COMMITTED snapshot does see tx1's inserted row.
+        The first-write case is decisive on its own."""
+        team = uuid.uuid4()
+        async with sm_no_index() as session:
+            await _budget_upsert(session, _budget(team, "50"), repo=_ForUpdateBudgetRepo)
+            await session.commit()
+        errs = await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"),
+                           repo=_ForUpdateBudgetRepo)
+        assert not errs, f"unexpected errors: {errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_BUDGETS, t=team) == 1
+
+    async def test_unlocked_global_rate_limit_upserts_duplicate(self, sm_no_index):
+        """#53, on the row that applies to every user."""
+        from app.models.model import RateLimitScope
+
+        errs = await _race(sm_no_index, _rl_upsert,
+                           _rate_limit(RateLimitScope.GLOBAL, None, 1000),
+                           _rate_limit(RateLimitScope.GLOBAL, None, 2000),
+                           repo=_LockFreeRateLimitRepo)
+        assert not errs, f"{errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_GLOBAL_LIMITS) == 2
+
+
+@_DB
+@pytest.mark.integration
+class TestTheAdvisoryLockFixesIt:
+    """Layer 1 alone, indexes absent: concurrent writes must now SUCCEED and converge."""
+
+    async def test_budget_first_write_for_a_new_team(self, sm_no_index):
+        team = uuid.uuid4()
+        errs = await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"))
+        assert not errs, f"concurrent budget writes must both succeed: {errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_BUDGETS, t=team) == 1
+
+    async def test_budget_update_of_an_existing_row(self, sm_no_index):
+        team = uuid.uuid4()
+        async with sm_no_index() as session:
+            await _budget_upsert(session, _budget(team, "50"))
+            await session.commit()
+        errs = await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"))
+        assert not errs, f"{errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_BUDGETS, t=team) == 1
+
+    async def test_the_last_committed_write_wins(self, sm_no_index):
+        """Serializing must also yield the right value. tx2 blocks on the lock, so it commits last
+        and its budget is the one in force — otherwise we would have traded a 500 for silent data
+        loss, which is worse."""
+        team = uuid.uuid4()
+        await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"))
+        assert await _scalar(
+            sm_no_index,
+            "SELECT max_budget_usd FROM budget.budget_configs "
+            "WHERE scope='TEAM' AND scope_id=:t AND is_active=true",
+            t=team,
+        ) == Decimal("200.0000")
+
+    async def test_budget_reads_stay_healthy(self, sm_no_index):
+        from app.models.budget import BudgetScope
+
+        team = uuid.uuid4()
+        await _race(sm_no_index, _budget_upsert, _budget(team, "100"), _budget(team, "200"))
+        async with sm_no_index() as session:
+            cfg = await BudgetRepository(session).get_active_config(BudgetScope.TEAM, team)
+        assert cfg is not None and cfg.max_budget_usd == Decimal("200.0000")
+
+    async def test_rate_limit_team_scope(self, sm_no_index):
+        from app.models.model import RateLimitScope
+
+        team = uuid.uuid4()
+        errs = await _race(sm_no_index, _rl_upsert,
+                           _rate_limit(RateLimitScope.TEAM, team, 60),
+                           _rate_limit(RateLimitScope.TEAM, team, 120))
+        assert not errs, f"{errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_LIMITS_FOR_TEAM, t=team) == 1
+
+    async def test_rate_limit_global_scope_with_null_scope_id(self, sm_no_index):
+        """GLOBAL is stored as scope_id=NULL (rate_limit_service, roi_aggregator), so the lock key
+        must survive a None part — and this is the highest blast-radius row in the table."""
+        from app.models.model import RateLimitScope
+
+        errs = await _race(sm_no_index, _rl_upsert,
+                           _rate_limit(RateLimitScope.GLOBAL, None, 1000),
+                           _rate_limit(RateLimitScope.GLOBAL, None, 2000))
+        assert not errs, f"{errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_GLOBAL_LIMITS) == 1
+
+    async def test_rate_limit_reads_stay_healthy(self, sm_no_index):
+        from app.models.model import RateLimitScope
+
+        team = uuid.uuid4()
+        await _race(sm_no_index, _rl_upsert,
+                    _rate_limit(RateLimitScope.TEAM, team, 60),
+                    _rate_limit(RateLimitScope.TEAM, team, 120))
+        async with sm_no_index() as session:
+            cfg = await RateLimitConfigRepository(session).get_active(RateLimitScope.TEAM, team)
+        assert cfg is not None and cfg.rpm_limit == 120
+
+    async def test_two_aliases_racing_on_one_scope_still_converge(self, sm_no_index):
+        """The behavioural reason the lock key omits model_alias. The upsert deactivates every
+        active row for the scope regardless of alias, so two concurrent writes carrying *different*
+        aliases are still writes to the same logical row. Keyed on alias they would take different
+        locks, race, and duplicate — which the static key guard catches, but this is the failure it
+        is guarding against."""
+        from app.models.model import RateLimitScope
+
+        team = uuid.uuid4()
+        errs = await _race(sm_no_index, _rl_upsert,
+                           _rate_limit(RateLimitScope.TEAM, team, 60, "alias-a"),
+                           _rate_limit(RateLimitScope.TEAM, team, 120, "alias-b"))
+        assert not errs, f"{errs}"
+        assert await _scalar(sm_no_index, _ACTIVE_LIMITS_FOR_TEAM, t=team) == 1
+
+
+@_DB
+@pytest.mark.integration
+class TestTheIndexIsAWorkingBackstop:
+    """Layer 2, exercised by the adversary repos: a writer that skips the lock must be stopped by
+    the database rather than corrupting the table."""
+
+    async def test_index_rejects_an_unlocked_budget_writer(self, sm):
+        team = uuid.uuid4()
+        errs = await _race(sm, _budget_upsert, _budget(team, "100"), _budget(team, "200"),
+                           repo=_LockFreeBudgetRepo)
+        assert len(errs) == 1, f"expected the unlocked loser to be rejected, got {errs}"
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team) == 1
+
+    async def test_index_rejects_an_unlocked_writer_of_the_null_client_row(self, sm):
+        """COALESCE(client, '') is what makes the index bite here; a plain 3-column index would let
+        two NULL-client rows coexist because NULL != NULL."""
+        team = uuid.uuid4()
+        errs = await _race(sm, _budget_upsert,
+                           _budget(team, "100", None), _budget(team, "200", None),
+                           repo=_LockFreeBudgetRepo)
+        assert len(errs) == 1, f"COALESCE(client,'') must treat two NULLs as equal, got {errs}"
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team) == 1
+
+    async def test_index_rejects_an_unlocked_writer_of_the_global_rate_limit(self, sm):
+        """The scope_id NULL trap. Without COALESCE(scope_id, nil) this lands two active GLOBAL
+        rows and every rate-limit read returns 500."""
+        from app.models.model import RateLimitScope
+
+        errs = await _race(sm, _rl_upsert,
+                           _rate_limit(RateLimitScope.GLOBAL, None, 1000),
+                           _rate_limit(RateLimitScope.GLOBAL, None, 2000),
+                           repo=_LockFreeRateLimitRepo)
+        assert len(errs) == 1, f"COALESCE(scope_id, nil) must treat two NULLs as equal, got {errs}"
+        assert await _scalar(sm, _ACTIVE_GLOBAL_LIMITS) == 1
+
+    async def test_index_does_not_fire_on_the_serialized_path(self, sm):
+        """The shipped combination. If the index fired here, the fix would have turned a rare 500
+        into a common one."""
+        team = uuid.uuid4()
+        errs = await _race(sm, _budget_upsert, _budget(team, "100"), _budget(team, "200"))
+        assert not errs, f"index must not fire when the lock already serialized: {errs}"
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team) == 1
+
+
+@_DB
+@pytest.mark.integration
+class TestLegitimateMultiRowCasesStillWork:
+    """Non-regression: the fix must not narrow what the product legitimately stores."""
+
+    async def test_different_teams_do_not_block_each_other(self, sm):
+        """The lock is per-key. If it were global — or keyed too coarsely — every concurrent admin
+        write would serialize, so team B must complete while team A's transaction is still open."""
+        from sqlalchemy import text
+
+        team_a, team_b = uuid.uuid4(), uuid.uuid4()
+        started, gate = asyncio.Event(), asyncio.Event()
+
+        async def hold_a():
+            async with sm() as session:
+                await _budget_upsert(session, _budget(team_a, "100"))
+                started.set()
+                await gate.wait()
+                await session.commit()
+
+        t1 = asyncio.create_task(hold_a())
+        await asyncio.wait_for(started.wait(), 10)
+        async with sm() as session:
+            await session.execute(text("SET lock_timeout = '3s'"))
+            await _budget_upsert(session, _budget(team_b, "300"))
+            await session.commit()          # must not wait on team A
+        gate.set()
+        await asyncio.wait_for(t1, 10)
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team_a) == 1
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team_b) == 1
+
+    async def test_per_app_budgets_coexist_with_the_total_budget(self, sm):
+        """The total row (client IS NULL) and one row per app are all active at once by design."""
+        team = uuid.uuid4()
+        for client in (None, "claude-code", "cowork", "codex"):
+            async with sm() as session:
+                await _budget_upsert(session, _budget(team, "10", client))
+                await session.commit()
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team) == 4
+
+    async def test_global_team_and_user_rate_limits_coexist(self, sm):
+        from app.models.model import RateLimitScope
+
+        team, user = uuid.uuid4(), uuid.uuid4()
+        for scope, scope_id in (
+            (RateLimitScope.GLOBAL, None),
+            (RateLimitScope.TEAM, team),
+            (RateLimitScope.USER, user),
+        ):
+            async with sm() as session:
+                await _rl_upsert(session, _rate_limit(scope, scope_id, 10))
+                await session.commit()
+        assert await _scalar(
+            sm, "SELECT count(*) FROM model.rate_limit_configs WHERE is_active=true"
+        ) == 3
+
+    async def test_repeated_updates_keep_history(self, sm):
+        """Partial index, so history rows accumulate freely while exactly one stays active."""
+        team = uuid.uuid4()
+        for amount in ("10", "20", "30", "40"):
+            async with sm() as session:
+                await _budget_upsert(session, _budget(team, amount))
+                await session.commit()
+        assert await _scalar(
+            sm, "SELECT count(*) FROM budget.budget_configs WHERE scope_id=:t", t=team
+        ) == 4
+        assert await _scalar(sm, _ACTIVE_BUDGETS, t=team) == 1

--- a/projects/awsome-ai-gateway/admin-ui/src/components/models/CreateModelDialog.tsx
+++ b/projects/awsome-ai-gateway/admin-ui/src/components/models/CreateModelDialog.tsx
@@ -128,10 +128,18 @@ export function CreateModelDialog({ isOpen, onClose, editModel }: CreateModelDia
         });
         onClose();
       } else {
-        setError(result.error);
-        if (!result.success && result.fieldErrors) {
-          setFieldErrors(result.fieldErrors);
-        }
+        // Field-error keys with no matching input in this form cannot be rendered by the JSX
+        // below, so they just disappear. That is exactly why the max_tokens/context_window
+        // schema drift showed up only as a "Validation failed" with no cause. Merge the
+        // unrenderable keys into the top-level error message so they are always visible.
+        const fe = (!result.success && result.fieldErrors) || {};
+        const orphanKeys = Object.keys(fe).filter((k) => !(k in form));
+        setError(
+          orphanKeys.length
+            ? `${result.error}: ${orphanKeys.map((k) => `${k} (${fe[k]})`).join(', ')}`
+            : result.error
+        );
+        setFieldErrors(fe);
       }
     });
   };
@@ -195,9 +203,10 @@ export function CreateModelDialog({ isOpen, onClose, editModel }: CreateModelDia
               <option value="">{t('selectProvider')}</option>
               <option value="BEDROCK">BEDROCK</option>
               <option value="OPENMODEL">OPENMODEL</option>
-              {/* Mantle 계열은 endpoint_url·api_format 이 필요해 보통 마이그레이션으로 시드되지만,
-                  기존 cowork-opus / codex-gpt 모델 편집(단가 등) 시 provider 드롭다운이 값과
-                  매칭되도록 옵션을 노출한다. */}
+              {/* Mantle providers need endpoint_url and api_format, so they are normally seeded
+                  by a migration. The options are still exposed here so the provider dropdown
+                  matches the stored value when editing existing cowork-opus / codex-gpt models
+                  (unit price, etc.). */}
               <option value="BEDROCK_MANTLE">BEDROCK_MANTLE (Cowork · Opus)</option>
               <option value="BEDROCK_MANTLE_OPENAI">BEDROCK_MANTLE_OPENAI (Codex · GPT)</option>
             </select>

--- a/projects/awsome-ai-gateway/admin-ui/src/types/api.ts
+++ b/projects/awsome-ai-gateway/admin-ui/src/types/api.ts
@@ -58,8 +58,6 @@ export interface ModelCreateForm {
   cache_creation_5m_price_per_1k: number;
   cache_creation_1h_price_per_1k: number;
   cache_read_price_per_1k: number;
-  max_tokens: number;
-  context_window: number;
   description?: string;
   display_name?: string;
 }
@@ -72,12 +70,18 @@ export const ModelCreateSchema = z.object({
   input_price_per_1k: z.number().nonnegative(),
   output_price_per_1k: z.number().nonnegative(),
   cache_creation_5m_price_per_1k: z.number().nonnegative().default(0),
-  // 1h 캐시쓰기 단가 — 과거 스키마 누락으로 폼 값이 strip 되어 백엔드 default 0 으로
-  // 박혀 1시간 캐시 사용분 청구가 누락되던 버그 수정(deepdive Q-pricing).
+  // 1h cache-write unit price. Fixes the bug where the field was missing from this schema, so
+  // the form value was stripped and pinned to the backend default of 0, dropping the charge for
+  // 1-hour cache usage (deepdive Q-pricing).
   cache_creation_1h_price_per_1k: z.number().nonnegative().default(0),
   cache_read_price_per_1k: z.number().nonnegative().default(0),
-  max_tokens: z.number().int().positive(),
-  context_window: z.number().int().positive(),
+  // NOTE: do not put max_tokens / context_window back here. The model create/edit form has no
+  // inputs for either field (they are absent from CreateModelDialog's FormState), and there is
+  // no matching field in the backend ModelCreateRequest or in the model.model_aliases table.
+  // If they stay required, the form has no way to send a value, so safeParse always fails with
+  // {max_tokens: Required, context_window: Required} and the screen shows only "Validation
+  // failed" with no per-field hint, blocking model creation and editing 100%.
+  // (Both fields exist only on the ModelListItem display type and are always filled with 0.)
   description: z.string().max(512).optional(),
   display_name: z.string().max(128).optional(),
 });

--- a/projects/awsome-ai-gateway/admin-ui/tests/unit/components/CreateModelDialog.test.tsx
+++ b/projects/awsome-ai-gateway/admin-ui/tests/unit/components/CreateModelDialog.test.tsx
@@ -1,0 +1,135 @@
+// Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+/**
+ * Create-model dialog — the reason a validation failed must be visible on screen.
+ *
+ * Background (real customer outage): the schema required keys the form does not
+ * have (max_tokens/context_window), so registration always failed, and because
+ * those keys have no matching <input> their fieldErrors were never rendered.
+ * Users only saw a bare "Validation failed" with no cause, leaving them unable
+ * to diagnose it themselves.
+ *
+ * Here we stub the server action so it returns a field error for a key that is
+ * not on the form, and assert that the key name shows up in the on-screen text.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CreateModelDialog } from '@/components/models/CreateModelDialog';
+
+const createModelAction = vi.fn();
+const updateModelAction = vi.fn();
+
+vi.mock('@/lib/actions/models', () => ({
+  createModelAction: (...a: unknown[]) => createModelAction(...a),
+  updateModelAction: (...a: unknown[]) => updateModelAction(...a),
+}));
+
+// next-intl throws without a message provider — stub it to return the key as-is.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const toast = vi.fn();
+vi.mock('@/components/common/ToastProvider', () => ({
+  useToast: () => ({ toast }),
+}));
+
+/** Fill the required inputs so submit is not blocked by browser required validation. */
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText(/Alias/), {
+    target: { name: 'alias', value: 'codex-gpt-5.6-sol' },
+  });
+  fireEvent.change(screen.getByLabelText(/Provider/), {
+    target: { name: 'provider', value: 'BEDROCK_MANTLE_OPENAI' },
+  });
+  fireEvent.change(screen.getByLabelText(/Model ID/), {
+    target: { name: 'model_id', value: 'openai.gpt-5.6-sol' },
+  });
+  fireEvent.change(screen.getByLabelText('priceInput'), {
+    target: { name: 'input_price_per_1k', value: '0.011' },
+  });
+  fireEvent.change(screen.getByLabelText('priceOutput'), {
+    target: { name: 'output_price_per_1k', value: '0.0495' },
+  });
+}
+
+describe('CreateModelDialog — validation failure observability', () => {
+  beforeEach(() => {
+    createModelAction.mockReset();
+    updateModelAction.mockReset();
+    toast.mockReset();
+  });
+
+  it('surfaces field errors for keys with no input on the form (regression: Validation failed with no cause)', async () => {
+    createModelAction.mockResolvedValue({
+      success: false,
+      error: 'Validation failed',
+      // Keys with no matching <input> on the form — these used to be dropped silently.
+      fieldErrors: { max_tokens: 'Required', context_window: 'Required' },
+    });
+
+    render(<CreateModelDialog isOpen onClose={() => {}} />);
+    fillRequiredFields();
+    fireEvent.submit(screen.getByRole('button', { name: 'register' }).closest('form')!);
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert').map((n) => n.textContent ?? '');
+      const joined = alerts.join(' | ');
+      expect(joined).toContain('Validation failed');
+      // The point: the offending key must be visible on screen.
+      expect(joined).toContain('max_tokens');
+      expect(joined).toContain('context_window');
+    });
+  });
+
+  it('shows errors for keys that do have an input only under that field, without polluting the top-level message', async () => {
+    createModelAction.mockResolvedValue({
+      success: false,
+      error: 'Validation failed',
+      fieldErrors: { alias: 'Alias is required' },
+    });
+
+    render(<CreateModelDialog isOpen onClose={() => {}} />);
+    fillRequiredFields();
+    fireEvent.submit(screen.getByRole('button', { name: 'register' }).closest('form')!);
+
+    await waitFor(() => {
+      const joined = screen.getAllByRole('alert').map((n) => n.textContent ?? '').join(' | ');
+      expect(joined).toContain('Alias is required');
+      // alias has a matching input, so the key name is not appended to the top summary.
+      expect(joined).not.toContain('alias (');
+    });
+  });
+
+  it('shows a toast and closes on success', async () => {
+    createModelAction.mockResolvedValue({ success: true, data: undefined });
+    const onClose = vi.fn();
+
+    render(<CreateModelDialog isOpen onClose={onClose} />);
+    fillRequiredFields();
+    fireEvent.submit(screen.getByRole('button', { name: 'register' }).closest('form')!);
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success' })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('does not put fields absent from the form into the submitted payload', async () => {
+    createModelAction.mockResolvedValue({ success: true, data: undefined });
+
+    render(<CreateModelDialog isOpen onClose={() => {}} />);
+    fillRequiredFields();
+    fireEvent.submit(screen.getByRole('button', { name: 'register' }).closest('form')!);
+
+    await waitFor(() => expect(createModelAction).toHaveBeenCalled());
+    const payload = createModelAction.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('max_tokens');
+    expect(payload).not.toHaveProperty('context_window');
+    expect(payload.alias).toBe('codex-gpt-5.6-sol');
+    expect(payload.provider).toBe('BEDROCK_MANTLE_OPENAI');
+  });
+});

--- a/projects/awsome-ai-gateway/admin-ui/tests/unit/lib/modelCreateSchema.test.ts
+++ b/projects/awsome-ai-gateway/admin-ui/tests/unit/lib/modelCreateSchema.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+/**
+ * Regression tests for the consistency between the model add/edit form, the zod schema,
+ * and the backend request schema.
+ *
+ * Background (real customer outage): ModelCreateSchema required `max_tokens`/`context_window`,
+ * but the CreateModelDialog form has no inputs for either field and never puts them in the
+ * payload. The backend ModelCreateRequest and the model.model_aliases table have no
+ * corresponding fields either.
+ * Result: every model add/edit always failed safeParse → the screen showed only
+ * "Validation failed". Worse, neither key has a matching <input>, so their fieldErrors were
+ * never rendered and the cause stayed invisible.
+ *
+ * These tests validate against "the payload the form actually builds", so putting a field
+ * the form does not have back into the schema fails immediately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ModelCreateSchema } from '@/types/api';
+
+/**
+ * Reproduces the payload construction in CreateModelDialog.handleSubmit exactly.
+ * (The form FormState is all strings; numbers go through parseFloat.)
+ */
+function buildPayloadLikeDialog(form: {
+  alias: string;
+  provider: string;
+  model_id: string;
+  endpoint_url: string;
+  input_price_per_1k: string;
+  output_price_per_1k: string;
+  cache_creation_5m_price_per_1k: string;
+  cache_creation_1h_price_per_1k: string;
+  cache_read_price_per_1k: string;
+  description: string;
+  display_name: string;
+}) {
+  return {
+    alias: form.alias,
+    provider: form.provider,
+    model_id: form.model_id,
+    endpoint_url: form.endpoint_url,
+    input_price_per_1k: parseFloat(form.input_price_per_1k),
+    output_price_per_1k: parseFloat(form.output_price_per_1k),
+    cache_creation_5m_price_per_1k: parseFloat(form.cache_creation_5m_price_per_1k || '0'),
+    cache_creation_1h_price_per_1k: parseFloat(form.cache_creation_1h_price_per_1k || '0'),
+    cache_read_price_per_1k: parseFloat(form.cache_read_price_per_1k || '0'),
+    description: form.description || undefined,
+    display_name: form.display_name || undefined,
+  };
+}
+
+/** The GPT-5.6 Sol registration values the customer actually entered (from the screenshot). */
+const GPT56_SOL_FORM = {
+  alias: 'codex-gpt-5.6-sol',
+  provider: 'BEDROCK_MANTLE_OPENAI',
+  model_id: 'openai.gpt-5.6-sol',
+  endpoint_url: 'https://bedrock-mantle.us-east-2.api.aws/openai',
+  input_price_per_1k: '0.011000',
+  output_price_per_1k: '0.049500',
+  cache_creation_5m_price_per_1k: '0.013750',
+  cache_creation_1h_price_per_1k: '0',
+  cache_read_price_per_1k: '0.001100',
+  description: '',
+  display_name: 'Codex · GPT-5.6 Sol',
+};
+
+describe('ModelCreateSchema — form payload consistency', () => {
+  it('accepts the GPT-5.6 Sol registration payload the customer entered (regression: Validation failed)', () => {
+    const parsed = ModelCreateSchema.safeParse(buildPayloadLikeDialog(GPT56_SOL_FORM));
+
+    // Surface the issues so a failure immediately shows which field blocked it.
+    const issues = parsed.success
+      ? []
+      : parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    expect(issues).toEqual([]);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('allows registering every Mantle/Bedrock/OPENMODEL provider', () => {
+    for (const provider of ['BEDROCK', 'OPENMODEL', 'BEDROCK_MANTLE', 'BEDROCK_MANTLE_OPENAI']) {
+      const parsed = ModelCreateSchema.safeParse(
+        buildPayloadLikeDialog({ ...GPT56_SOL_FORM, provider })
+      );
+      expect(parsed.success, `provider=${provider}`).toBe(true);
+    }
+  });
+
+  it('keeps the schema required keys inside the key set the form sends (drift guard)', () => {
+    // The keys the form can actually produce. If the schema requires a key that is not
+    // listed here, the user can never fill in a value for it.
+    const KEYS_THE_FORM_CAN_SEND = new Set([
+      'alias',
+      'provider',
+      'model_id',
+      'endpoint_url',
+      'input_price_per_1k',
+      'output_price_per_1k',
+      'cache_creation_5m_price_per_1k',
+      'cache_creation_1h_price_per_1k',
+      'cache_read_price_per_1k',
+      'description',
+      'display_name',
+    ]);
+
+    // Parse an empty object to extract the keys that fail when no value is given
+    // (i.e. effectively required). Keys with optional / .default() do not show up here.
+    const empty = ModelCreateSchema.safeParse({});
+    const requiredKeys = empty.success
+      ? []
+      : [...new Set(empty.error.issues.map((i) => i.path.join('.')))];
+
+    const unreachable = requiredKeys.filter((k) => !KEYS_THE_FORM_CAN_SEND.has(k));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('passes when description and display name are empty (optional fields)', () => {
+    const parsed = ModelCreateSchema.safeParse(
+      buildPayloadLikeDialog({ ...GPT56_SOL_FORM, description: '', display_name: '' })
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  it('attaches the error to the field itself when a required field is empty (the hint must be visible on screen)', () => {
+    const parsed = ModelCreateSchema.safeParse(
+      buildPayloadLikeDialog({ ...GPT56_SOL_FORM, alias: '', model_id: '' })
+    );
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const keys = parsed.error.issues.map((i) => i.path.join('.'));
+      expect(keys).toContain('alias');
+      expect(keys).toContain('model_id');
+    }
+  });
+
+  it('rejects negative unit prices', () => {
+    const parsed = ModelCreateSchema.safeParse(
+      buildPayloadLikeDialog({ ...GPT56_SOL_FORM, input_price_per_1k: '-0.01' })
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a missing unit price (NaN) — it must not silently bill at 0', () => {
+    // Leaving the input empty makes parseFloat('') === NaN.
+    const parsed = ModelCreateSchema.safeParse(
+      buildPayloadLikeDialog({ ...GPT56_SOL_FORM, input_price_per_1k: '' })
+    );
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/projects/awsome-ai-gateway/db/init/02_create_tables.sql
+++ b/projects/awsome-ai-gateway/db/init/02_create_tables.sql
@@ -137,6 +137,13 @@ CREATE TABLE IF NOT EXISTS budget.budget_configs (
 
 CREATE INDEX IF NOT EXISTS idx_budget_configs_scope ON budget.budget_configs (scope, scope_id) WHERE is_active = true;
 
+-- Two rows with is_active=true under the same key make every later lookup fail with
+-- MultipleResultsFound → 500 in scalar_one_or_none() (see migration 0024). COALESCE is required —
+-- org-wide budget rows (client IS NULL) are not covered by plain (scope, scope_id, client).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_budget_configs_active
+    ON budget.budget_configs (scope, scope_id, COALESCE(client, ''))
+    WHERE is_active = true;
+
 CREATE TABLE IF NOT EXISTS budget.budget_usages (
     id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     scope                   budget.budget_scope NOT NULL,
@@ -227,6 +234,15 @@ CREATE TABLE IF NOT EXISTS model.rate_limit_configs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_rate_limit_configs_scope ON model.rate_limit_configs (scope, scope_id) WHERE is_active = true;
+
+-- Same as migration 0024. model_alias is deliberately not part of the key — the upsert
+-- deactivates every active row for the scope regardless of alias, so including alias
+-- would open a real duplicate window. COALESCE(scope_id, ...) is required — GLOBAL scope
+-- has scope_id IS NULL, and NULLs are distinct in a unique index, so plain
+-- (scope, scope_id) would not cover it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_rate_limit_configs_active
+    ON model.rate_limit_configs (scope, COALESCE(scope_id, '00000000-0000-0000-0000-000000000000'::uuid))
+    WHERE is_active = true;
 
 -- ------------------------------------------------------------
 -- 팀별 모델 접근 제어

--- a/projects/awsome-ai-gateway/db/versions/0024_unique_active_config_indexes.py
+++ b/projects/awsome-ai-gateway/db/versions/0024_unique_active_config_indexes.py
@@ -1,0 +1,125 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+"""partial UNIQUE indexes on budget_configs / rate_limit_configs active rows
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-08-11
+
+Both tables are versioned: an upsert sets the previous row's is_active=false and inserts a new
+active row. Concurrent upserts of the same key (admin double-click, ALB retry, two uvicorn
+workers) could each deactivate against a stale snapshot and then insert, leaving TWO
+is_active=true rows. Reads use scalar_one_or_none(), so from that moment every read of that scope
+raises MultipleResultsFound -> HTTP 500, permanently. The corruption is silent until the next read.
+
+The write paths now take a transaction-scoped advisory lock (app/repositories/_locks.py); these
+indexes are the database-level backstop for any writer that does not.
+
+NULL handling is the subtle part -- NULLs are distinct in a unique index, so an index over a
+nullable column does not constrain NULL rows at all:
+  * budget_configs.client   IS NULL for the org-wide budget  -> COALESCE(client, '')
+  * rate_limit_configs.scope_id IS NULL for GLOBAL scope     -> COALESCE(scope_id, nil UUID)
+Without the COALESCE, the exact rows that matter most (the org budget, the global rate limit)
+would remain unprotected. The nil UUID is safe as a sentinel because gen_random_uuid() (v4)
+cannot produce it.
+
+rate_limit_configs is keyed WITHOUT model_alias on purpose: RateLimitConfigRepository.upsert()
+is alias-blind (it deactivates every active row for the scope), so at most one active row per
+scope is intended. Including model_alias would leave the real duplicate window open.
+
+Pre-existing duplicates: CREATE UNIQUE INDEX fails outright if any exist, which would abort the
+migration and block deployment. Deployed installations may already have them, so this migration
+first collapses each duplicate group to its newest row (the value an operator last submitted and
+therefore expects to see) and logs what it touched.
+"""
+from alembic import op
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Keep only the newest row per logical key; older duplicates are demoted, not deleted, so the
+# history stays auditable and the change is reversible by inspection.
+DEDUPE_BUDGET_CONFIGS = """
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY scope, scope_id, COALESCE(client, '')
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM budget.budget_configs
+    WHERE is_active = true
+)
+UPDATE budget.budget_configs c
+   SET is_active = false
+  FROM ranked r
+ WHERE c.id = r.id AND r.rn > 1
+"""
+
+DEDUPE_RATE_LIMIT_CONFIGS = f"""
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY scope, COALESCE(scope_id, '{NIL_UUID}'::uuid)
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM model.rate_limit_configs
+    WHERE is_active = true
+)
+UPDATE model.rate_limit_configs c
+   SET is_active = false
+  FROM ranked r
+ WHERE c.id = r.id AND r.rn > 1
+"""
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Report before mutating: an operator seeing a non-zero count here knows that scope was
+    # already returning 500s and that a stale budget/limit may have been in force.
+    for label, sql in (
+        (
+            "budget.budget_configs",
+            "SELECT count(*) FROM ("
+            "  SELECT 1 FROM budget.budget_configs WHERE is_active = true"
+            "  GROUP BY scope, scope_id, COALESCE(client, '') HAVING count(*) > 1"
+            ") d",
+        ),
+        (
+            "model.rate_limit_configs",
+            "SELECT count(*) FROM ("
+            "  SELECT 1 FROM model.rate_limit_configs WHERE is_active = true"
+            f"  GROUP BY scope, COALESCE(scope_id, '{NIL_UUID}'::uuid) HAVING count(*) > 1"
+            ") d",
+        ),
+    ):
+        dupes = conn.exec_driver_sql(sql).scalar()
+        if dupes:
+            print(
+                f"[0024] {label}: {dupes} key(s) had multiple active rows; "
+                f"keeping the newest per key and deactivating the rest"
+            )
+
+    op.execute(DEDUPE_BUDGET_CONFIGS)
+    op.execute(DEDUPE_RATE_LIMIT_CONFIGS)
+
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_budget_configs_active "
+        "ON budget.budget_configs (scope, scope_id, COALESCE(client, '')) "
+        "WHERE is_active = true"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_rate_limit_configs_active "
+        f"ON model.rate_limit_configs (scope, COALESCE(scope_id, '{NIL_UUID}'::uuid)) "
+        "WHERE is_active = true"
+    )
+
+
+def downgrade() -> None:
+    # Only the indexes are dropped. The dedupe is not reverted: re-activating rows would
+    # recreate the MultipleResultsFound corruption this migration exists to remove.
+    op.execute("DROP INDEX IF EXISTS model.uq_rate_limit_configs_active")
+    op.execute("DROP INDEX IF EXISTS budget.uq_budget_configs_active")

--- a/projects/awsome-ai-gateway/db/versions/0025_add_gpt56_aliases.py
+++ b/projects/awsome-ai-gateway/db/versions/0025_add_gpt56_aliases.py
@@ -1,0 +1,212 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+"""add GPT-5.6 Sol / Terra / Luna aliases + official Bedrock pricing
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-08-11
+
+Three aliases on the same wire as 0017's ``codex-gpt`` (BEDROCK_MANTLE_OPENAI /
+OPENAI_RESPONSES, enum values committed by 0016), so no enum change is needed:
+
+  codex-gpt-5.6-sol    -> openai.gpt-5.6-sol      coding / long-horizon agentic work
+  codex-gpt-5.6-terra  -> openai.gpt-5.6-terra    balanced default
+  codex-gpt-5.6-luna   -> openai.gpt-5.6-luna     cheapest, high-volume
+
+REGION: us-east-2 (Ohio), matching 0017 and the codex routing profile.
+
+Region choice is constrained from two sides and us-east-2 is the only value that
+satisfies both:
+  * Sol is available in us-east-1 and us-east-2 ONLY -- NOT us-west-2 (per the
+    2026-08-06 model-card region matrix), so any all-three-model region is east.
+  * ``local.mantle_regions`` in deployment/terraform/modules/irsa/main.tf is
+    ["ap-northeast-1", "us-east-2"], and the IAM statements scope
+    bedrock-mantle:CreateInference/GetInference per region. us-east-1 would need a
+    terraform apply first; us-east-2 works with the IAM already deployed.
+Adding a MODEL needs no IAM change (the resource ARNs are model-wildcarded);
+adding a REGION does. Also note the bearer is region-bound via SigV4
+(MantleCredentialBroker.bearer_token signs with profile.region), so an alias whose
+endpoint_url region differs from routing_profiles.region gets a 401 -- keep them equal.
+
+default_model is deliberately NOT changed. ``routing_profiles.codex.default_model``
+stays 'codex-gpt' (GPT-5.5) so an operator whose account cannot yet reach the GPT-5.6
+models (IAM ``bedrock-mantle:*`` not yet granted, or the region lacks the model) keeps
+a working client; GPT-5.6 is opt-in per request
+(``{"model": "codex-gpt-5.6-terra"}``, honored by the /v1/responses per-request
+selection in routers/openai_compat.py). Switch the default with:
+    UPDATE model.routing_profiles SET default_model = 'codex-gpt-5.6-terra'
+     WHERE client = 'codex';
+...then flush the Redis routing-profile cache or wait out its 300s TTL:
+    DEL routing_profile:codex
+The key is ``routing_profile:{client}`` -- NOT ``routing:{client}``. Verified against
+services/routing_profile_loader.py:32 (``cache_key = f"routing_profile:{client}"``) and
+admin-api services/routing_profile_service.py:20 (``_CACHE_KEY``). Deleting the wrong
+key silently no-ops, leaving a stale profile served for up to 5 minutes.
+
+PRICING is the official AWS Bedrock public pricing as of 2026-08-06 (NOT a placeholder,
+unlike 0017's codex-gpt row), converted from USD/1M to the table's USD/1k:
+
+  model  | in/1M | cache write/1M | cache read/1M | out/1M
+  Sol    |  5.50 |  6.875         | 0.55          | 33.00
+  Terra  |  2.20 |  2.75          | 0.22          | 13.20
+  Luna   |  0.22 |  0.275         | 0.022         |  1.32
+
+Two properties of these numbers matter for the schema:
+
+1) 5m and 1h cache-write columns get the SAME value. Bedrock publishes ONE cache-write
+   rate for the OpenAI models (deck footer: "30M CACHE WRITE / CACHE READ"); the
+   5m/1h split in model_pricings exists for Anthropic's two TTLs. Putting a different
+   number in the 1h column would invent a rate AWS does not publish. In practice the
+   value is unreachable on this path anyway: cost_recorder picks the 1h rate only when
+   usage.cache_ttl_1h is true, which is set exclusively in routers/messages.py
+   (Anthropic dialect), never on the Responses path.
+
+2) These are the SHORT-context (<=272K input) rates. Bedrock bills a request whose
+   input exceeds 272K entirely at the long-context rate (2x input/cache, ~1.5x output),
+   which model_pricings cannot express -- it has one rate per alias, with no input-size
+   band. Long-context requests are therefore UNDER-billed by this table. Recording the
+   short rate is the correct choice for the common case; an operator who expects
+   routine >272K prompts should register a separate alias with the long rates.
+   Cost is recorded from the provider's own usage object, so tokens are never wrong --
+   only the per-token rate applied to them.
+
+3) PRE-EXISTING, NOT introduced here: cached prompt tokens are counted TWICE on this
+   dialect. OpenAI's Responses usage.input_tokens ALREADY INCLUDES
+   input_tokens_details.cached_tokens, but services/cost_recorder.calculate_cost bills
+   input_tokens at the full input rate AND cache_read_input_tokens at the cache-read
+   rate on top. A heavily-cached request is therefore over-billed (a 90%-cached Sol
+   prompt bills roughly 4.6x the correct amount).
+
+   This is a property of the Anthropic-shaped TokenUsage/pricing model, where
+   input_tokens EXCLUDES cache tokens, being reused for OpenAI accounting where it does
+   not. It applies identically to 0017's codex-gpt and to every Mantle-OpenAI alias, so
+   these three rows neither cause nor worsen it -- they only make it more visible,
+   because Sol's rates are ~4.4x codex-gpt's. Fixing it means subtracting cached_tokens
+   from the billable input (in the adapter or the cost path), which changes billing for
+   an ALREADY-DEPLOYED alias and so is deliberately out of scope for this migration.
+
+reasoning_tokens are billed inside output_tokens (OpenAI accounting), so there is no
+separate reasoning price column -- reasoning stays a visibility submetric (see
+providers/mantle_openai_adapter._extract_responses_usage).
+"""
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+SYSTEM_USER = "00000000-0000-4000-a000-000000000010"
+ENDPOINT = "https://bedrock-mantle.us-east-2.api.aws/openai"
+EFFECTIVE_FROM = "2026-08-06T00:00:00Z"  # date of the AWS pricing page these rates come from
+
+# (alias, provider_model_id, display_name, description,
+#  input/1k, cache_write/1k, cache_read/1k, output/1k)
+MODELS = [
+    (
+        "codex-gpt-5.6-sol",
+        "openai.gpt-5.6-sol",
+        "Codex · GPT-5.6 Sol",
+        "Codex -> 859 Bedrock Mantle GPT-5.6 Sol (Ohio, Responses API) — coding / agentic",
+        "0.005500", "0.006875", "0.000550", "0.033000",
+    ),
+    (
+        "codex-gpt-5.6-terra",
+        "openai.gpt-5.6-terra",
+        "Codex · GPT-5.6 Terra",
+        "Codex -> 859 Bedrock Mantle GPT-5.6 Terra (Ohio, Responses API) — balanced",
+        "0.002200", "0.002750", "0.000220", "0.013200",
+    ),
+    (
+        "codex-gpt-5.6-luna",
+        "openai.gpt-5.6-luna",
+        "Codex · GPT-5.6 Luna",
+        "Codex -> 859 Bedrock Mantle GPT-5.6 Luna (Ohio, Responses API) — high volume",
+        "0.000220", "0.000275", "0.000022", "0.001320",
+    ),
+]
+
+
+def upgrade() -> None:
+    for alias, model_id, display_name, description, p_in, p_cw, p_cr, p_out in MODELS:
+        op.execute(
+            f"""
+            INSERT INTO model.model_aliases
+                (alias, provider, provider_model_id, endpoint_url, api_format, status,
+                 description, display_name, created_by)
+            VALUES
+                ('{alias}', 'BEDROCK_MANTLE_OPENAI', '{model_id}',
+                 '{ENDPOINT}', 'OPENAI_RESPONSES', 'ACTIVE',
+                 '{description}', '{display_name}', '{SYSTEM_USER}')
+            ON CONFLICT (alias) DO NOTHING
+            """
+        )
+
+        # model_pricings PK is gen_random_uuid(), so ON CONFLICT cannot dedupe;
+        # guard on (model_alias, effective_from) like 03_seed_data.sql does. Keying on
+        # effective_from (not just the alias) keeps a future price revision insertable.
+        op.execute(
+            f"""
+            INSERT INTO model.model_pricings
+                (id, model_alias, input_price_per_1k_tokens, output_price_per_1k_tokens,
+                 cache_creation_5m_price_per_1k_tokens, cache_creation_1h_price_per_1k_tokens,
+                 cache_read_price_per_1k_tokens, effective_from, created_by)
+            SELECT gen_random_uuid(), '{alias}',
+                   {p_in}, {p_out}, {p_cw}, {p_cw}, {p_cr},
+                   '{EFFECTIVE_FROM}', '{SYSTEM_USER}'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM model.model_pricings
+                 WHERE model_alias = '{alias}' AND effective_from = '{EFFECTIVE_FROM}'
+            )
+            """
+        )
+
+
+def downgrade() -> None:
+    """Remove the three aliases and everything that references them.
+
+    SIX tables carry a FK to model_aliases.alias and NONE of them cascade
+    (all ON DELETE NO ACTION, verified against the live catalog):
+
+        model.model_pricings        .model_alias
+        model.team_allowed_models   .model_alias      <- grants, written by admin-api
+        model.user_allowed_models   .model_alias      <- grants, written by admin-api
+        model.rate_limit_configs    .model_alias
+        budget.downgrade_policies   .from_model_alias
+        budget.downgrade_policies   .to_model_alias
+
+    Deleting only the pricing row is not enough: as soon as an operator grants one of
+    these models to a team or user (the normal way to make it usable), downgrade dies
+    with ForeignKeyViolationError. Because env.py runs with transaction_per_migration,
+    that rollback leaves the DB pinned at 0025 with no way down -- reproduced against
+    real Postgres with a single team_allowed_models row.
+
+    These child rows are all configuration ABOUT an alias that is going away, so
+    removing them is the correct inverse of upgrade(), not collateral damage. Deletes
+    are ordered children-before-parent.
+
+    routing_profiles has no FK (default_model is a plain column), so it is repaired by
+    UPDATE rather than DELETE -- dropping an alias that a profile still points at would
+    leave a dangling default and 404 every codex request.
+    """
+    aliases = ", ".join(f"'{m[0]}'" for m in MODELS)
+
+    op.execute(
+        f"""
+        UPDATE model.routing_profiles
+           SET default_model = 'codex-gpt'
+         WHERE client = 'codex' AND default_model IN ({aliases})
+        """
+    )
+
+    for table, column in (
+        ("model.model_pricings", "model_alias"),
+        ("model.team_allowed_models", "model_alias"),
+        ("model.user_allowed_models", "model_alias"),
+        ("model.rate_limit_configs", "model_alias"),
+        ("budget.downgrade_policies", "from_model_alias"),
+        ("budget.downgrade_policies", "to_model_alias"),
+    ):
+        op.execute(f"DELETE FROM {table} WHERE {column} IN ({aliases})")
+
+    op.execute(f"DELETE FROM model.model_aliases WHERE alias IN ({aliases})")

--- a/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
@@ -314,6 +314,48 @@ ensure_observability() {
 }
 
 # ---- Helm install / upgrade ----
+# SET_ARGS 는 helm_install 이 조립하고 patch_nextauth_url 이 재사용하므로 전역.
+declare -a SET_ARGS=()
+
+# ---- 과거 patch_nextauth_url 이 남긴 field ownership 정리 ----
+# 증상: helm upgrade 가 이 에러로 실패.
+#   conflict with "helm" using apps/v1:
+#     .spec.template.spec.containers[name="admin-ui"].env[name="NEXTAUTH_URL"].value
+#
+# 원인: k8s server-side apply 의 소유권 키는 manager *이름* 이 아니라
+# (이름, operation) 쌍이다. `kubectl set env` 는 operation=Update 로 기록되고,
+# helm 은 operation=Apply 로 기록한다. 따라서 과거 코드의 `--field-manager=helm` 은
+# 소유권을 helm 에 넘겨준 게 아니라, 이름만 같고 operation 이 다른 *두 번째* 소유자를
+# 만들었다. 에러 메시지의 `using apps/v1` 접미사가 그 증거 —
+# k8s 는 충돌 상대가 Update 소유자일 때만 이 접미사를 붙인다.
+#
+# 조치: 그 Update 항목만 managedFields 에서 제거해 helm(Apply) 단독 소유로 되돌린다.
+# `--force-conflicts` 를 쓰지 않는 이유: 그건 릴리즈 전체에 적용돼서, HPA 가 소유한
+# .spec.replicas 까지 helm 이 덮어써 스케일이 되돌아간다 (이 클러스터는 HPA 사용).
+prune_stale_field_managers() {
+    local deploy="${RELEASE_NAME}-admin-ui"
+    kubectl get deployment "$deploy" -n "$NAMESPACE" >/dev/null 2>&1 || return 0
+
+    # operation=Update 이면서 manager 가 helm / kubectl-set 인 항목의 인덱스.
+    # 뒤에서부터 지워야 앞쪽 인덱스가 밀리지 않는다.
+    local idxs
+    idxs=$(kubectl get deployment "$deploy" -n "$NAMESPACE" -o json 2>/dev/null \
+        | jq -r '[.metadata.managedFields | to_entries[]
+                  | select(.value.operation == "Update")
+                  | select(.value.manager == "helm" or .value.manager == "kubectl-set")
+                  | .key] | reverse | .[]' 2>/dev/null || true)
+    [ -z "$idxs" ] && return 0
+
+    warn "admin-ui 에 과거 'kubectl set env' 소유권 잔존 → 정리 (helm 충돌 예방)"
+    local i
+    for i in $idxs; do
+        kubectl patch deployment "$deploy" -n "$NAMESPACE" --type=json \
+            -p="[{\"op\":\"remove\",\"path\":\"/metadata/managedFields/$i\"}]" \
+            >/dev/null 2>&1 || true
+    done
+    ok "admin-ui field ownership 정리 완료"
+}
+
 helm_install() {
     info "Helm ${HELM_ACTION} 실행 중"
 
@@ -326,7 +368,7 @@ helm_install() {
     local ecr_registry="${aws_account_id}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
     # --set 명령 조립
-    local -a set_args=(
+    SET_ARGS=(
         --set "global.imageRegistry=${ecr_registry}"
         --set "aws.region=${AWS_REGION}"
         --set "database.external.host=${AURORA_HOST}"
@@ -339,7 +381,7 @@ helm_install() {
 
     # OIDC (Cognito) — terraform 에서 만든 경우 자동 주입
     if [ -n "${COGNITO_ISSUER_URL}" ]; then
-        set_args+=(
+        SET_ARGS+=(
             --set "adminApi.oidc.enabled=true"
             --set "adminApi.oidc.issuerUrl=${COGNITO_ISSUER_URL}"
             --set "adminApi.oidc.providerName=oidc:cognito"
@@ -358,7 +400,7 @@ helm_install() {
     # 전체가 helm install 한 번에 끝남. 비활성화 하려면 MIGRATION_ENABLED=false env 사용.
     if [ "${MIGRATION_ENABLED:-true}" != "true" ]; then
         warn "Migration Job 비활성화 (MIGRATION_ENABLED=false). 별도 수동 실행 필요"
-        set_args+=(--set "migration.enabled=false")
+        SET_ARGS+=(--set "migration.enabled=false")
     fi
 
     # helm upgrade --install 로 통합: release 없으면 install, 있으면 upgrade.
@@ -373,7 +415,7 @@ helm_install() {
         helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
             --namespace "$NAMESPACE" \
             --values "$VALUES_FILE" \
-            "${set_args[@]}" \
+            "${SET_ARGS[@]}" \
             --timeout 15m \
             --wait
     else
@@ -382,7 +424,7 @@ helm_install() {
             helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
                 --namespace "$NAMESPACE" \
                 --values "$VALUES_FILE" \
-                "${set_args[@]}" \
+                "${SET_ARGS[@]}" \
                 --force-conflicts \
                 --rollback-on-failure \
                 --cleanup-on-fail \
@@ -392,7 +434,7 @@ helm_install() {
             helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
                 --namespace "$NAMESPACE" \
                 --values "$VALUES_FILE" \
-                "${set_args[@]}" \
+                "${SET_ARGS[@]}" \
                 --rollback-on-failure \
                 --cleanup-on-fail \
                 --timeout 15m \
@@ -446,12 +488,24 @@ patch_nextauth_url() {
         ok "NEXTAUTH_URL 이미 올바름 — 스킵"
         return
     fi
-    # --field-manager=helm 으로 NEXTAUTH_URL 소유권을 Helm 이 계속 보유하도록.
-    # (기본 manager 'kubectl-set' 로 설정되면 다음 helm upgrade 에서 server-side apply 충돌.)
-    kubectl set env deployment/"${RELEASE_NAME}-admin-ui" -n "$NAMESPACE" \
-        --field-manager=helm \
-        NEXTAUTH_URL="$nextauth_url" >/dev/null
-    kubectl rollout status deployment/"${RELEASE_NAME}-admin-ui" -n "$NAMESPACE" --timeout=3m
+
+    # `kubectl set env` 대신 helm upgrade 로 되돌린다 (--set adminUi.nextauthUrl=...).
+    # chart 의 default 표현식이 이 값을 그대로 쓰므로 결과 env 는 동일하고,
+    # 소유자는 helm(Apply) 하나로 유지된다 → 다음 배포에서 충돌이 발생하지 않는다.
+    # (과거 kubectl set env 방식이 만든 Update 소유자가 바로 이번 배포 실패의 원인.)
+    #
+    # migration.enabled=false: 방금 같은 실행의 helm_install 이 이미 alembic upgrade 를
+    # 돌렸다. 이 두 번째 upgrade 는 env 한 개만 바꾸는 것이므로 pre-upgrade
+    # migration hook 을 다시 띄울 이유가 없다 (재실행은 no-op 이지만 배포가 수 분 길어짐).
+    # --set 은 이 호출에만 적용되고 릴리즈 values 에 누적되지 않는다.
+    helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
+        --namespace "$NAMESPACE" \
+        --values "$VALUES_FILE" \
+        "${SET_ARGS[@]}" \
+        --set "adminUi.nextauthUrl=${nextauth_url}" \
+        --set "migration.enabled=false" \
+        --timeout 5m \
+        --wait
     ok "admin-ui NEXTAUTH_URL 패치 완료"
 }
 
@@ -492,6 +546,7 @@ main() {
     ensure_cluster_secret_store
     check_secrets_manager
     preinstall_cleanup_es_artifacts
+    prune_stale_field_managers
     helm_install
     patch_nextauth_url
     verify_deployment

--- a/projects/awsome-ai-gateway/gateway-cli/locales/en/LC_MESSAGES/gateway-cli.po
+++ b/projects/awsome-ai-gateway/gateway-cli/locales/en/LC_MESSAGES/gateway-cli.po
@@ -31,3 +31,22 @@ msgstr "Setup Summary"
 
 msgid "Gateway URL is required. Use --gateway-url option or set in config.yaml."
 msgstr "Gateway URL is required. Use --gateway-url option or set in config.yaml."
+
+msgid "  OIDC:            (not set) — api-key-helper will run in STS(IAM) mode."
+msgstr "  OIDC:            (not set) — api-key-helper will run in STS(IAM) mode."
+
+msgid ""
+"                   To use IDP login: run 'gateway-cli login' and retry, or\n"
+"                   pass --issuer-url / --client-id."
+msgstr ""
+"                   To use IDP login: run 'gateway-cli login' and retry, or\n"
+"                   pass --issuer-url / --client-id."
+
+msgid "    Auth Mode:       OIDC (IDP identity)"
+msgstr "    Auth Mode:       OIDC (IDP identity)"
+
+msgid "    Auth Mode:       STS (IAM ARN identity) — OIDC not configured"
+msgstr "    Auth Mode:       STS (IAM ARN identity) — OIDC not configured"
+
+msgid "                     To use IDP login, re-run 'gateway-cli setup' (auto-detected when run after login)"
+msgstr "                     To use IDP login, re-run 'gateway-cli setup' (auto-detected when run after login)"

--- a/projects/awsome-ai-gateway/gateway-cli/locales/ko/LC_MESSAGES/gateway-cli.po
+++ b/projects/awsome-ai-gateway/gateway-cli/locales/ko/LC_MESSAGES/gateway-cli.po
@@ -31,3 +31,22 @@ msgstr "설정 요약"
 
 msgid "Gateway URL is required. Use --gateway-url option or set in config.yaml."
 msgstr "Gateway URL이 필요합니다. --gateway-url 옵션을 지정하거나 config.yaml에 설정하세요."
+
+msgid "  OIDC:            (not set) — api-key-helper will run in STS(IAM) mode."
+msgstr "  OIDC:            (미설정) — api-key-helper 가 STS(IAM) 모드로 동작합니다."
+
+msgid ""
+"                   To use IDP login: run 'gateway-cli login' and retry, or\n"
+"                   pass --issuer-url / --client-id."
+msgstr ""
+"                   IDP 로그인을 쓰려면: gateway-cli login 후 재실행하거나\n"
+"                   --issuer-url / --client-id 를 지정하세요."
+
+msgid "    Auth Mode:       OIDC (IDP identity)"
+msgstr "    Auth Mode:       OIDC (IDP 신원 기준)"
+
+msgid "    Auth Mode:       STS (IAM ARN identity) — OIDC not configured"
+msgstr "    Auth Mode:       STS (IAM ARN 기준) — OIDC 미설정"
+
+msgid "                     To use IDP login, re-run 'gateway-cli setup' (auto-detected when run after login)"
+msgstr "                     IDP 로그인을 쓰려면 'gateway-cli setup' 재실행 (login 후 실행 시 자동 감지)"

--- a/projects/awsome-ai-gateway/gateway-cli/src/api_key_helper/main.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/api_key_helper/main.py
@@ -358,11 +358,29 @@ def _detect_mode(explicit_mode: str | None) -> str:
     """Return 'oidc' or 'sts'.
 
     Explicit override > env auto-detect > legacy sts default.
+
+    Partial configuration is warned about: when only one of the two vars is set
+    the OIDC intent is obvious, yet the mode silently falls back to STS and the
+    user — who did log in through the IDP — is provisioned as a *different user*
+    keyed on the IAM ARN (auto-provisioning in admin-api
+    services/cli_service.py: email = ``<session_name>@unknown``). The user then
+    cannot find their own account in the Admin UI user list and usage
+    accumulates under that ARN user — very hard to track down.
     """
     if explicit_mode in ("oidc", "sts"):
         return explicit_mode
-    if os.environ.get("OIDC_ISSUER_URL") and os.environ.get("OIDC_CLIENT_ID"):
+    issuer = os.environ.get("OIDC_ISSUER_URL")
+    client_id = os.environ.get("OIDC_CLIENT_ID")
+    if issuer and client_id:
         return "oidc"
+    if issuer or client_id:
+        missing = "OIDC_CLIENT_ID" if issuer else "OIDC_ISSUER_URL"
+        print(
+            f"Warning: {missing} is not set, so STS(IAM) mode is used instead of OIDC. "
+            "The VK is issued for your AWS IAM ARN, not your IDP login identity. "
+            f"To use OIDC, set {missing} or pass --auth-mode oidc.",
+            file=sys.stderr,
+        )
     return "sts"
 
 

--- a/projects/awsome-ai-gateway/gateway-cli/src/cli/managed.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/cli/managed.py
@@ -51,25 +51,51 @@ def read_gateway_settings() -> dict | None:
         return None
 
 
-def write_gateway_settings(
+def build_gateway_settings(
     gateway_url: str,
     admin_api_url: str,
     api_key_helper_path: str,
     otel_endpoint: str | None = None,
     otel_auth_token: str | None = None,
-) -> Path:
-    """Write gateway managed settings file.
+    oidc_issuer_url: str | None = None,
+    oidc_client_id: str | None = None,
+    oidc_audience: str | None = None,
+) -> dict:
+    """Assemble the managed-settings document (pure — no filesystem, no sudo).
+
+    Split out of :func:`write_gateway_settings` so the env block can be unit
+    tested without sudo; the write path is a thin wrapper around this.
 
     gateway_url:   Gateway proxy URL (ANTHROPIC_BASE_URL — for Claude Code API calls)
     admin_api_url: Admin API URL (GATEWAY_CLI_GATEWAY_URL — for api-key-helper VK issuance)
 
-    Requires root/admin — uses sudo on Linux/WSL.
-    Returns the path of the written file.
+    OIDC_ISSUER_URL / OIDC_CLIENT_ID are written because ``apiKeyHelper`` runs as a
+    *child of Claude Code*, so its only configuration channel is this ``env`` block —
+    it does not inherit the operator's shell. api_key_helper._detect_mode requires
+    BOTH vars to pick OIDC mode; with neither present it silently selects STS(IAM)
+    mode, which either issues a VK against the caller's AWS IAM ARN (wrong user —
+    admin-api provisions ``<session_name>@unknown``) or, with no SSO session, prints
+    nothing to stdout and exits 1. Claude Code then has no credential and falls back
+    to its own first-party login prompt ("Not logged in · Please run /login") — i.e.
+    the redirect-to-1P symptom. Omitting these two keys was the defect;
+    guides/user-guide.md §5.2 has always told manual users to set all four.
     """
     env: dict[str, str] = {
         "ANTHROPIC_BASE_URL": gateway_url,
         "GATEWAY_CLI_GATEWAY_URL": admin_api_url,
     }
+
+    # OIDC (IDP) — the two vars api-key-helper requires to operate in OIDC mode.
+    # ADMIN_API_URL is not written separately: gateway_cli_oidc.load_oidc_config_from_env
+    # falls back to ``ADMIN_API_URL or GATEWAY_CLI_GATEWAY_URL``, so the key above already
+    # covers that role (writing the same value under two keys drifts once only one is updated).
+    if oidc_issuer_url and oidc_client_id:
+        env["OIDC_ISSUER_URL"] = oidc_issuer_url.rstrip("/")
+        env["OIDC_CLIENT_ID"] = oidc_client_id
+        # audience is optional — needed only when admin-api's OIDC_AUDIENCE check is enabled.
+        # An empty string is omitted instead: audience handling differs per IDP and can cause 401.
+        if oidc_audience:
+            env["OIDC_AUDIENCE"] = oidc_audience
 
     # Claude Code client-side OTEL (metrics + traces + code activity)
     if otel_endpoint:
@@ -82,12 +108,39 @@ def write_gateway_settings(
         if otel_auth_token:
             env["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Bearer {otel_auth_token}"
 
-    settings = {
+    return {
         "_comment": "LLM Gateway — managed by gateway-cli",
         "env": env,
         "apiKeyHelper": api_key_helper_path,
         "statusLine": {"type": "command", "command": "statusline"},
     }
+
+
+def write_gateway_settings(
+    gateway_url: str,
+    admin_api_url: str,
+    api_key_helper_path: str,
+    otel_endpoint: str | None = None,
+    otel_auth_token: str | None = None,
+    oidc_issuer_url: str | None = None,
+    oidc_client_id: str | None = None,
+    oidc_audience: str | None = None,
+) -> Path:
+    """Write gateway managed settings file.
+
+    Requires root/admin — uses sudo on Linux/WSL.
+    Returns the path of the written file.
+    """
+    settings = build_gateway_settings(
+        gateway_url=gateway_url,
+        admin_api_url=admin_api_url,
+        api_key_helper_path=api_key_helper_path,
+        otel_endpoint=otel_endpoint,
+        otel_auth_token=otel_auth_token,
+        oidc_issuer_url=oidc_issuer_url,
+        oidc_client_id=oidc_client_id,
+        oidc_audience=oidc_audience,
+    )
 
     content = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
     target = _managed_file()

--- a/projects/awsome-ai-gateway/gateway-cli/src/cli/setup.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/cli/setup.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Optional
 
 import click
@@ -14,6 +15,50 @@ from cli.managed import is_gateway_enabled, write_gateway_settings
 from cli.tools.bedrock_config import resolve_helper_path
 
 log = structlog.get_logger(component="cli")
+
+
+def _resolve_oidc(
+    issuer_url: Optional[str], client_id: Optional[str]
+) -> tuple[str, str, str]:
+    """Resolve (issuer_url, client_id, source) for the managed env block.
+
+    Priority: CLI option > env var > ``gateway-cli login`` token cache. The returned
+    source label describes where the *issuer* came from (it is printed on that line).
+
+    The token cache is included because it is the one source that is guaranteed
+    correct: ``login`` records the issuer/client it actually authenticated against.
+    A user who ran ``login`` then ``setup`` in a fresh shell (the documented order in
+    scripts/onboard-macos-linux.sh, where the env vars live only in the first shell)
+    would otherwise get managed settings with no OIDC keys at all — and api-key-helper
+    silently falls back to STS. Returns ("", "", "") when nothing resolves.
+    """
+    src = "option" if issuer_url else "env"
+    issuer_url = (issuer_url or os.environ.get("OIDC_ISSUER_URL", "")).rstrip("/")
+    client_id = client_id or os.environ.get("OIDC_CLIENT_ID", "")
+
+    if not (issuer_url and client_id):
+        try:
+            from gateway_cli_oidc.oidc_client import load_tokens
+
+            tokens = load_tokens()
+        except Exception:  # noqa: BLE001 — cache is best-effort, never fatal
+            tokens = None
+        cached_issuer = (getattr(tokens, "issuer_url", "") or "").rstrip("/")
+        cached_client = getattr(tokens, "client_id", "") or ""
+        # The cache is only valid as an (issuer, client_id) pair. Borrowing just one
+        # half builds a combination that never existed, so api-key-helper enters OIDC
+        # mode and then dies in _get_valid_tokens with "cached tokens belong to a
+        # different IDP" (worse than the STS fallback — no VK at all). If an issuer is
+        # already given, borrow client_id only when the cache is for the same IDP.
+        if cached_issuer and cached_client and issuer_url in ("", cached_issuer):
+            if not issuer_url:
+                issuer_url, src = cached_issuer, "login cache"
+            if not client_id:
+                client_id, src = cached_client, "login cache"
+
+    if issuer_url and client_id:
+        return issuer_url, client_id, src
+    return "", "", ""
 
 
 @click.command()
@@ -37,8 +82,32 @@ log = structlog.get_logger(component="cli")
     default=None,
     help="OpenTelemetry collector endpoint (e.g. http://otel-collector:4317)",
 )
+@click.option(
+    "--issuer-url",
+    default=None,
+    help="OIDC issuer URL. Defaults to $OIDC_ISSUER_URL, then the 'gateway-cli login' cache.",
+)
+@click.option(
+    "--client-id",
+    default=None,
+    help="OIDC client_id. Defaults to $OIDC_CLIENT_ID, then the 'gateway-cli login' cache.",
+)
+@click.option(
+    "--audience",
+    default=None,
+    help="OIDC audience. Only needed if admin-api has OIDC_AUDIENCE verification enabled.",
+)
 @click.pass_context
-def setup(ctx: click.Context, gateway_url: Optional[str], admin_api_url: Optional[str], api_key_helper: Optional[str], otel_endpoint: Optional[str]) -> None:
+def setup(
+    ctx: click.Context,
+    gateway_url: Optional[str],
+    admin_api_url: Optional[str],
+    api_key_helper: Optional[str],
+    otel_endpoint: Optional[str],
+    issuer_url: Optional[str],
+    client_id: Optional[str],
+    audience: Optional[str],
+) -> None:
     """Enable LLM Gateway for Claude Code.
 
     Writes managed settings to /etc/claude-code/managed-settings.d/
@@ -70,6 +139,7 @@ def setup(ctx: click.Context, gateway_url: Optional[str], admin_api_url: Optiona
         otel_endpoint = f"http://{p.hostname}:4317"
     otel = otel_endpoint or config.otel_endpoint or None
     helper_path = api_key_helper or resolve_helper_path()
+    oidc_issuer, oidc_client, oidc_src = _resolve_oidc(issuer_url, client_id)
 
     if is_gateway_enabled():
         click.echo(_("Gateway is already enabled. Updating settings..."))
@@ -79,6 +149,25 @@ def setup(ctx: click.Context, gateway_url: Optional[str], admin_api_url: Optiona
     click.echo(f"  API Key Helper:  {helper_path}")
     if otel:
         click.echo(f"  OTEL Endpoint:   {otel}")
+    if oidc_issuer:
+        click.echo(f"  OIDC Issuer:     {oidc_issuer}  (from {oidc_src})")
+        click.echo(f"  OIDC Client ID:  {oidc_client}")
+    else:
+        # Staying silent here drops api-key-helper into STS(IAM) mode, so the VK is
+        # issued against the AWS ARN instead of the IDP identity (the wrong user), or
+        # with no SSO session no VK is issued at all and Claude Code falls back to the
+        # 1P login screen. Warn visibly.
+        click.secho(
+            _("  OIDC:            (not set) — api-key-helper will run in STS(IAM) mode."),
+            fg="yellow",
+        )
+        click.secho(
+            _(
+                "                   To use IDP login: run 'gateway-cli login' and retry, or\n"
+                "                   pass --issuer-url / --client-id."
+            ),
+            fg="yellow",
+        )
     click.echo("")
 
     try:
@@ -88,6 +177,9 @@ def setup(ctx: click.Context, gateway_url: Optional[str], admin_api_url: Optiona
             api_key_helper_path=helper_path,
             otel_endpoint=otel,
             otel_auth_token=config.otel_auth_token or None,
+            oidc_issuer_url=oidc_issuer or None,
+            oidc_client_id=oidc_client or None,
+            oidc_audience=audience or os.environ.get("OIDC_AUDIENCE") or None,
         )
         click.secho(f"  Gateway enabled: {path}", fg="green")
         click.echo("")

--- a/projects/awsome-ai-gateway/gateway-cli/src/cli/status.py
+++ b/projects/awsome-ai-gateway/gateway-cli/src/cli/status.py
@@ -37,6 +37,28 @@ def status(ctx: click.Context) -> None:
         otel = env.get('OTEL_EXPORTER_OTLP_ENDPOINT')
         if otel:
             click.echo(f"    OTEL Endpoint:   {otel}")
+
+        # api-key-helper only runs in OIDC mode when BOTH OIDC keys are present
+        # (api_key_helper.main._detect_mode). With either one missing it silently
+        # falls back to STS(IAM), so the VK is issued for the wrong user or Claude
+        # Code drops back to first-party login — surface the mode here in status.
+        issuer, client = env.get("OIDC_ISSUER_URL"), env.get("OIDC_CLIENT_ID")
+        if issuer and client:
+            click.echo(f"    OIDC Issuer:     {issuer}")
+            click.echo(f"    OIDC Client ID:  {client}")
+            click.echo(_("    Auth Mode:       OIDC (IDP identity)"))
+        else:
+            click.secho(
+                _("    Auth Mode:       STS (IAM ARN identity) — OIDC not configured"),
+                fg="yellow",
+            )
+            click.secho(
+                _(
+                    "                     To use IDP login, re-run 'gateway-cli setup'"
+                    " (auto-detected when run after login)"
+                ),
+                fg="yellow",
+            )
     else:
         click.secho("  Gateway: [OFF]", fg="red", bold=True)
         click.echo("    Claude Code uses direct API access.")

--- a/projects/awsome-ai-gateway/gateway-cli/tests/unit/test_managed_oidc.py
+++ b/projects/awsome-ai-gateway/gateway-cli/tests/unit/test_managed_oidc.py
@@ -1,0 +1,187 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+"""managed-settings OIDC env block + OIDC value resolution in setup.
+
+Regression target: ``gateway-cli setup`` did not write OIDC_ISSUER_URL /
+OIDC_CLIENT_ID, so api-key-helper silently fell back to STS (IAM) mode. That
+splits into two outcomes and customers hit both — (1) a VK issued to a
+*different user*, resolved from the AWS ARN, (2) with no SSO session, no VK at
+all, so Claude Code falls back to 1P login.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cli.managed import build_gateway_settings
+from cli.setup import _resolve_oidc
+
+
+def _base(**kw) -> dict:
+    args = dict(
+        gateway_url="https://gw.example.com",
+        admin_api_url="https://admin.example.com",
+        api_key_helper_path="/usr/local/bin/api-key-helper",
+    )
+    args.update(kw)
+    return build_gateway_settings(**args)
+
+
+class TestBuildGatewaySettingsOIDC:
+    def test_writes_both_oidc_keys(self) -> None:
+        env = _base(
+            oidc_issuer_url="https://idp.example.com/tenant",
+            oidc_client_id="client-abc",
+        )["env"]
+        assert env["OIDC_ISSUER_URL"] == "https://idp.example.com/tenant"
+        assert env["OIDC_CLIENT_ID"] == "client-abc"
+
+    def test_trailing_slash_stripped(self) -> None:
+        """The issuer must match the token's iss exactly, and it is also used as a cache key."""
+        env = _base(
+            oidc_issuer_url="https://idp.example.com/tenant/",
+            oidc_client_id="c",
+        )["env"]
+        assert env["OIDC_ISSUER_URL"] == "https://idp.example.com/tenant"
+
+    def test_partial_config_writes_neither(self) -> None:
+        """Only one of the two still falls back to STS, so don't write a misleading half config."""
+        env = _base(oidc_issuer_url="https://idp.example.com")["env"]
+        assert "OIDC_ISSUER_URL" not in env
+        assert "OIDC_CLIENT_ID" not in env
+
+    def test_audience_omitted_when_blank(self) -> None:
+        """Writing an empty audience can cause a 401, since IDPs interpret it differently."""
+        env = _base(
+            oidc_issuer_url="https://idp.example.com", oidc_client_id="c",
+            oidc_audience="",
+        )["env"]
+        assert "OIDC_AUDIENCE" not in env
+
+    def test_audience_written_when_given(self) -> None:
+        env = _base(
+            oidc_issuer_url="https://idp.example.com", oidc_client_id="c",
+            oidc_audience="api://gateway",
+        )["env"]
+        assert env["OIDC_AUDIENCE"] == "api://gateway"
+
+    def test_no_oidc_keeps_previous_behaviour(self) -> None:
+        """Without OIDC, the existing 2 keys + helper path stay unchanged (no regression)."""
+        s = _base()
+        assert s["env"] == {
+            "ANTHROPIC_BASE_URL": "https://gw.example.com",
+            "GATEWAY_CLI_GATEWAY_URL": "https://admin.example.com",
+        }
+        assert s["apiKeyHelper"] == "/usr/local/bin/api-key-helper"
+
+    def test_admin_api_url_not_duplicated(self) -> None:
+        """ADMIN_API_URL falls back to GATEWAY_CLI_GATEWAY_URL, so it is not written twice."""
+        env = _base(
+            oidc_issuer_url="https://idp.example.com", oidc_client_id="c",
+        )["env"]
+        assert "ADMIN_API_URL" not in env
+
+    def test_otel_block_unaffected(self) -> None:
+        env = _base(
+            otel_endpoint="http://otel:4317", otel_auth_token="tok",
+            oidc_issuer_url="https://idp.example.com", oidc_client_id="c",
+        )["env"]
+        assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://otel:4317"
+        assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "Authorization=Bearer tok"
+        assert env["OIDC_CLIENT_ID"] == "c"
+
+
+class TestResolveOIDC:
+    def test_option_wins_over_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("OIDC_ISSUER_URL", "https://env.example.com")
+        monkeypatch.setenv("OIDC_CLIENT_ID", "env-client")
+        issuer, client, src = _resolve_oidc("https://opt.example.com", "opt-client")
+        assert (issuer, client) == ("https://opt.example.com", "opt-client")
+        assert src == "option"
+
+    def test_env_used_when_no_option(self, monkeypatch) -> None:
+        monkeypatch.setenv("OIDC_ISSUER_URL", "https://env.example.com/")
+        monkeypatch.setenv("OIDC_CLIENT_ID", "env-client")
+        issuer, client, src = _resolve_oidc(None, None)
+        assert (issuer, client, src) == ("https://env.example.com", "env-client", "env")
+
+    def test_falls_back_to_login_cache(self, monkeypatch) -> None:
+        """Supports the documented order: run login, then run setup from a new shell."""
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+
+        class _Tok:
+            issuer_url = "https://cached.example.com"
+            client_id = "cached-client"
+
+        with patch("gateway_cli_oidc.oidc_client.load_tokens", return_value=_Tok()):
+            issuer, client, src = _resolve_oidc(None, None)
+        assert (issuer, client, src) == (
+            "https://cached.example.com", "cached-client", "login cache",
+        )
+
+    def test_empty_when_nothing_available(self, monkeypatch) -> None:
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+        with patch("gateway_cli_oidc.oidc_client.load_tokens", return_value=None):
+            assert _resolve_oidc(None, None) == ("", "", "")
+
+    def test_cache_error_is_not_fatal(self, monkeypatch) -> None:
+        """setup must proceed even when the token cache is corrupt (in STS mode)."""
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+        with patch(
+            "gateway_cli_oidc.oidc_client.load_tokens", side_effect=OSError("boom")
+        ):
+            assert _resolve_oidc(None, None) == ("", "", "")
+
+    def test_option_issuer_plus_env_client(self, monkeypatch) -> None:
+        """Partial sources count as OIDC as long as they combine into a complete pair."""
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.setenv("OIDC_CLIENT_ID", "env-client")
+        issuer, client, _src = _resolve_oidc("https://opt.example.com", None)
+        assert (issuer, client) == ("https://opt.example.com", "env-client")
+
+    def test_cache_client_borrowed_only_for_same_idp(self, monkeypatch) -> None:
+        """Borrowing a cached client_id from a different IDP produces a pair that does not exist.
+
+        With that pair, api-key-helper enters OIDC mode and then dies on 'different IDP',
+        so no VK is issued at all (worse than the STS fallback). It must not borrow.
+        """
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+
+        class _Tok:
+            issuer_url = "https://other-idp.example.com"
+            client_id = "other-client"
+
+        with patch("gateway_cli_oidc.oidc_client.load_tokens", return_value=_Tok()):
+            assert _resolve_oidc("https://my-idp.example.com", None) == ("", "", "")
+
+    def test_cache_client_borrowed_when_issuer_matches(self, monkeypatch) -> None:
+        """For the same IDP, borrowing just the client_id from the cache is correct."""
+        monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+
+        class _Tok:
+            issuer_url = "https://my-idp.example.com/"  # trailing slash on the cache side
+            client_id = "cached-client"
+
+        with patch("gateway_cli_oidc.oidc_client.load_tokens", return_value=_Tok()):
+            issuer, client, src = _resolve_oidc("https://my-idp.example.com", None)
+        assert (issuer, client, src) == (
+            "https://my-idp.example.com", "cached-client", "login cache",
+        )
+
+    def test_env_issuer_reported_as_env_source(self, monkeypatch) -> None:
+        """Issuer from env but client_id from the cache — the label must point at the cache."""
+        monkeypatch.setenv("OIDC_ISSUER_URL", "https://my-idp.example.com")
+        monkeypatch.delenv("OIDC_CLIENT_ID", raising=False)
+
+        class _Tok:
+            issuer_url = "https://my-idp.example.com"
+            client_id = "cached-client"
+
+        with patch("gateway_cli_oidc.oidc_client.load_tokens", return_value=_Tok()):
+            _issuer, client, src = _resolve_oidc(None, None)
+        assert (client, src) == ("cached-client", "login cache")

--- a/projects/awsome-ai-gateway/gateway-clients/README.md
+++ b/projects/awsome-ai-gateway/gateway-clients/README.md
@@ -41,7 +41,8 @@ cd gateway-clients
   Claude Code 가 `/v1/messages` 를 게이트웨이로 호출. 게이트웨이가 `client=claude-code` 로 식별.
 - **codex-box**: entrypoint 가 `~/.codex/config.toml` 을 생성(`base_url=<게이트웨이>/v1`,
   `wire_api="responses"`, `env_key=GATEWAY_VK`) → Codex 가 `/v1/responses` 로 GPT-5.5 호출.
-  Codex 가 보내는 `originator: codex_cli_rs` 헤더로 게이트웨이가 `client=codex` 식별.
+  Codex 가 보내는 `originator` 헤더로 게이트웨이가 `client=codex` 식별 — 대화형은 `codex_cli_rs`,
+  `codex exec` 는 `codex_exec` 이고 판정이 `startswith("codex")` 라서 둘 다 인식된다.
 - **VK**: 호스트 `~/.gateway-vk`(plain 문자열, 600)에서 읽어 컨테이너에 env 주입. 호스트 환경 무변경.
   1시간 만료 → `./gw.sh vk` 재실행.
 

--- a/projects/awsome-ai-gateway/gateway-clients/gw.sh
+++ b/projects/awsome-ai-gateway/gateway-clients/gw.sh
@@ -76,11 +76,29 @@ PY
     if command -v gateway-cli >/dev/null 2>&1; then
       gateway-cli login --issuer-url "$OIDC_ISSUER_URL" --client-id "$OIDC_CLIENT_ID"
       VK="$(python3 - "$ADMIN_URL" <<'PY'
-import json,os,sys,urllib.request
-tok=json.load(open(os.path.expanduser("~/.gateway-cli/oidc-tokens.json")))["access_token"]
+import json,os,sys,urllib.error,urllib.request
+# id_token 을 보낸다 (access_token 아님). 이유:
+#  1) 사용자 신원 claim(email/name/groups)이 id_token 에만 있다. Cognito access_token
+#     에는 email 이 없어 admin-api 가 <sub>@unknown 으로 프로비저닝한다.
+#  2) Entra ID 는 access_token 의 aud 가 리소스(예: MS Graph)로 발급되므로
+#     admin-api 의 OIDC_AUDIENCE(=client_id) 검증에 걸려 401 이 된다.
+# admin-api 도 id_token 을 전제로 동작한다
+# (core/oidc_verifier.py 의 verify_at_hash=False 주석 참조).
+p=os.path.expanduser("~/.gateway-cli/oidc-tokens.json")
+try:
+    d=json.load(open(p))
+except FileNotFoundError:
+    sys.exit(f"토큰 캐시 없음: {p} — 'gateway-cli login' 이 실패했습니다.")
+tok=d.get("id_token") or ""
+if not tok:
+    sys.exit("id_token 이 없습니다. IdP 앱 등록에 'openid' scope 가 있는지 확인하세요.")
 req=urllib.request.Request(sys.argv[1]+"/v1/auth/exchange",data=b"{}",method="POST",
   headers={"Authorization":"Bearer "+tok,"Content-Type":"application/json"})
-print(json.load(urllib.request.urlopen(req,timeout=15))["virtual_key"])
+try:
+    print(json.load(urllib.request.urlopen(req,timeout=15))["virtual_key"])
+except urllib.error.HTTPError as e:
+    # 401/403 을 조용히 삼키면 "왜 안 되는지" 알 수 없다. 본문을 그대로 노출.
+    sys.exit(f"exchange 실패 HTTP {e.code}: {e.read().decode('utf-8','replace')[:500]}")
 PY
 )"
       printf '%s' "$VK" > "$VK_FILE"; chmod 600 "$VK_FILE"

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/openai_compat.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/routers/openai_compat.py
@@ -8,10 +8,11 @@ import time
 import structlog
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.exc import DBAPIError
 
 from app.schemas.domain import ProviderType, TokenUsage
 from app.schemas.responses import ModelObject, ModelPricingObject, ModelsListResponse
-from app.services.router_service import RouterService
+from app.services.router_service import ModelInactiveError, RouterService
 from app.services.streaming import openai_sse_stream
 
 logger = structlog.get_logger(__name__)
@@ -331,6 +332,107 @@ async def _handle_responses(request: Request):
             return None
         return await routing_loader.load(redis, db, client)
 
+    # Per-request model selection (added with the GPT-5.6 Sol/Terra/Luna aliases).
+    #
+    # Before this, the profile's default_model was the ONLY reachable model on this
+    # route, so registering three GPT-5.6 aliases would have left all three
+    # unreachable: a client sending {"model": "codex-gpt-5.6-sol"} still got the
+    # default. Now the client's own model wins WHEN it resolves to an ACTIVE
+    # BEDROCK_MANTLE_OPENAI alias.
+    #
+    # Falling back (rather than 404ing) on an unresolvable value is what makes this
+    # change regression-free for existing clients: Codex always sends SOME model id,
+    # typically an upstream OpenAI name like "gpt-5.5-codex" that is not one of our
+    # aliases. Before this change that value was ignored; a strict lookup would turn
+    # every such request into a 404. The default_model path below is therefore reached
+    # by exactly the requests that reached it before.
+    #
+    # This is NOT an entitlement bypass: whatever is resolved goes through
+    # check_key_scope() below, which matches against {alias, provider_model_id}. A key
+    # scoped to codex-gpt cannot reach a GPT-5.6 alias by asking for it.
+    #
+    # KNOWN COST, accepted: a model name we do not register costs 2 extra indexed
+    # SELECTs (alias match, then provider_model_id match) before the fallback, on every
+    # such request -- failed lookups are not negatively cached, and a Codex client sends
+    # the same unregistered name every time. Measured: exactly 2 queries per miss.
+    # Accepted rather than optimised because the alternative (caching negative lookups)
+    # would delay a newly-registered alias becoming reachable, and an operator adding a
+    # model expects it to work immediately. If this ever shows up in DB load, negatively
+    # cache the miss with a TTL well under MODEL_CACHE_TTL rather than reordering these
+    # lookups -- and note the cost lands only on clients sending unregistered names.
+    def _is_usable_model_ref(value) -> bool:
+        """True only for a value we can safely hand to the resolver.
+
+        "model" comes straight from untrusted client JSON, so it is not necessarily a
+        usable string, and an unusable one must not reach the resolver: the resolver's
+        failures below are caught as LookupError, but these two failure modes are NOT
+        LookupError, so they would escape the fallback and 500 a request that returned
+        200 before this feature existed.
+
+          * non-str (number/list/dict/bool) → asyncpg gets a non-text bind for a VARCHAR
+            comparison and raises DBAPIError. Verified against real Postgres with
+            123 / ["a"] / {"x":1} / True.
+          * lone UTF-16 surrogate (e.g. {"model": "\\ud800"}) → valid JSON and a real str,
+            but redis-py encodes cache keys with encoding_errors="strict", so
+            redis.get(f"model:{ref}") raises UnicodeEncodeError before any DB call.
+            Verified directly against redis-py's Encoder.
+          * NUL byte (e.g. {"model": "codex\\u0000gpt"}) → valid JSON, a real str, and
+            encodes to UTF-8 cleanly, so neither check above catches it. Postgres has no
+            NUL in text: asyncpg raises CharacterNotInRepertoireError ("invalid byte
+            sequence for encoding UTF8: 0x00"). Verified against real Postgres.
+
+        All are rejected here rather than caught below, so the profile default serves
+        them exactly as it did before per-request selection.
+
+        Deliberately NOT rejected: an over-long value. Postgres compares
+        `alias = $1` by VALUE, not by the column's declared width, so a 100 000-char ref
+        simply matches nothing and falls back (verified: HTTP 200). Length is bounded
+        for LOGGING only, at the log call below.
+        """
+        if not isinstance(value, str) or not value or "\x00" in value:
+            return False
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError:
+            return False
+        return True
+
+    async def _resolve_model(db, profile):
+        """Resolve the client-sent model, falling back to the profile default."""
+        if _is_usable_model_ref(requested_alias) and requested_alias != profile.default_model:
+            try:
+                return await _router_service.resolve_codex_model(redis, db, requested_alias)
+            except ModelInactiveError:
+                # Do NOT fall back. status=INACTIVE is an operator kill switch: an alias
+                # that exists but was deliberately disabled must be refused, not quietly
+                # served as some other model (which would also bill the wrong alias).
+                # Propagates as a 404 via the LookupError handler below.
+                raise
+            except (LookupError, DBAPIError):
+                # The alias is genuinely not ours (unknown name, or a different
+                # provider's alias) → the pre-existing behaviour: profile default.
+                #
+                # DBAPIError is a deliberate backstop, not a substitute for the guard
+                # above: "model" is untrusted client JSON, and a driver-level rejection
+                # of some value we did not anticipate must degrade to the default (the
+                # pre-feature behaviour) rather than 500 a request that used to succeed.
+                # It is caught HERE only — around the *requested* model. The default
+                # model's own lookup below is left to propagate, because a broken
+                # default is a real server fault and must not be hidden.
+                #
+                # INFO, not DEBUG: this is a silent model substitution, so it has to be
+                # visible at the default log level to be diagnosable. Truncated to the
+                # alias column's own width (128): the value is unbounded client input,
+                # and logging it verbatim turns one request into a multi-MB log line,
+                # while nothing legitimate is ever longer than the column allows.
+                logger.info(
+                    "responses_requested_model_unresolved_using_default",
+                    requested=requested_alias[:128],
+                    default_model=profile.default_model,
+                    client=client,
+                )
+        return await _router_service.resolve_codex_model(redis, db, profile.default_model)
+
     try:
         if not is_db_degraded and session_factory is not None:
             async with session_factory() as db:
@@ -341,9 +443,7 @@ async def _handle_responses(request: Request):
                         content={"error": {"type": "not_found",
                                             "message": "No Responses backend for this client"}},
                     )
-                model_config = await _router_service.resolve_codex_model(
-                    redis, db, profile.default_model
-                )
+                model_config = await _resolve_model(db, profile)
         else:
             profile = await _load_profile(None)
             if profile is None or profile.backend != "mantle" or not profile.default_model:
@@ -352,9 +452,7 @@ async def _handle_responses(request: Request):
                     content={"error": {"type": "not_found",
                                         "message": "No Responses backend for this client"}},
                 )
-            model_config = await _router_service.resolve_codex_model(
-                redis, None, profile.default_model
-            )
+            model_config = await _resolve_model(None, profile)
     except LookupError as e:
         return JSONResponse(
             status_code=404, content={"error": {"type": "not_found", "message": str(e)}}
@@ -392,8 +490,10 @@ async def _handle_responses(request: Request):
     adapter = registry.get(ProviderType.BEDROCK_MANTLE_OPENAI)
     rate_limit_state = state.get("rate_limit_state")
 
-    # Rewrite the outgoing model id to the resolved provider_model_id (e.g. openai.gpt-5.5),
-    # so the alias the client sent (codex-gpt / openai.gpt-5.5) maps to the Mantle model.
+    # Rewrite the outgoing model id to the resolved provider_model_id (e.g. openai.gpt-5.5,
+    # openai.gpt-5.6-terra), so the alias the client sent (codex-gpt-5.6-terra) — or the
+    # profile default, when the client sent something we do not recognise — maps to the
+    # Mantle model. Mantle only accepts provider model ids, never our aliases.
     if isinstance(req_data, dict):
         req_data["model"] = model_config.provider_model_id
         body = json.dumps(req_data).encode()

--- a/projects/awsome-ai-gateway/gateway-proxy/src/app/services/router_service.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/src/app/services/router_service.py
@@ -26,6 +26,17 @@ MODEL_CACHE_TTL = 300  # 5분
 MODEL_LIST_CACHE_TTL = 300
 
 
+class ModelInactiveError(LookupError):
+    """An alias exists and matches the expected provider, but its status is INACTIVE.
+
+    A LookupError subclass so every existing ``except LookupError`` keeps behaving
+    exactly as before (callers that only care "could not resolve" need no change).
+    The distinction matters where a caller FALLS BACK on a failed lookup: setting
+    status=INACTIVE is an operator kill switch, so it must deny the request rather
+    than silently reroute it to some other model (see routers/openai_compat.py).
+    """
+
+
 def check_client_scope(allowed_clients: list[str] | None, client: str | None) -> None:
     """Raise PermissionError if the identified client is not allowed for this user.
 
@@ -120,7 +131,7 @@ class RouterService:
                 schema = _parse_cached_model(cached, model_ref)
                 if schema is not None:
                     if schema.status == ModelStatus.INACTIVE:
-                        raise LookupError(f"Model '{schema.alias or model_ref}' is inactive")
+                        raise ModelInactiveError(f"Model '{schema.alias or model_ref}' is inactive")
                     if schema.provider != ProviderType.BEDROCK:
                         raise LookupError(f"Model alias '{model_ref}' not found")
                     return schema
@@ -155,7 +166,7 @@ class RouterService:
             raise LookupError(f"Model alias '{model_ref}' not found")
 
         if alias_row.status != "ACTIVE":
-            raise LookupError(f"Model '{alias_row.alias}' is inactive")
+            raise ModelInactiveError(f"Model '{alias_row.alias}' is inactive")
 
         pricing_row = await _fetch_latest_pricing(db, alias_row.alias)
         schema = _orm_to_schema(alias_row, pricing_row)
@@ -191,7 +202,7 @@ class RouterService:
                 schema = _parse_cached_model(cached, model_ref)
                 if schema is not None:
                     if schema.status == ModelStatus.INACTIVE:
-                        raise LookupError(f"Model '{schema.alias or model_ref}' is inactive")
+                        raise ModelInactiveError(f"Model '{schema.alias or model_ref}' is inactive")
                     if schema.provider != expected_provider:
                         raise LookupError(f"Model alias '{model_ref}' not found")
                     return schema
@@ -226,7 +237,7 @@ class RouterService:
             raise LookupError(f"Model alias '{model_ref}' not found")
 
         if alias_row.status != "ACTIVE":
-            raise LookupError(f"Model '{alias_row.alias}' is inactive")
+            raise ModelInactiveError(f"Model '{alias_row.alias}' is inactive")
 
         pricing_row = await _fetch_latest_pricing(db, alias_row.alias)
         schema = _orm_to_schema(alias_row, pricing_row)
@@ -295,7 +306,7 @@ class RouterService:
                 schema = _parse_cached_model(cached, alias)
                 if schema is not None:
                     if schema.status == ModelStatus.INACTIVE:
-                        raise LookupError(f"Model '{alias}' is inactive")
+                        raise ModelInactiveError(f"Model '{alias}' is inactive")
                     if schema.provider != ProviderType.OPENMODEL:
                         raise LookupError(f"Model '{alias}' not found")
                     return schema
@@ -316,7 +327,7 @@ class RouterService:
         if alias_row is None:
             raise LookupError(f"Model '{alias}' not found")
         if alias_row.status != "ACTIVE":
-            raise LookupError(f"Model '{alias}' is inactive")
+            raise ModelInactiveError(f"Model '{alias}' is inactive")
 
         pricing_row = await _fetch_latest_pricing(db, alias_row.alias)
         schema = _orm_to_schema(alias_row, pricing_row)

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_responses_model_selection.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_responses_model_selection.py
@@ -1,0 +1,585 @@
+# Copyright 2026 © Amazon.com and Affiliates: This deliverable is considered Developed Content as defined in the AWS Service Terms.
+
+"""Per-request model selection on /v1/responses (GPT-5.6 Sol / Terra / Luna).
+
+Before this feature the routing profile's ``default_model`` was the only reachable
+model on this route, so the three GPT-5.6 aliases added by migration 0025 would have
+been unreachable. These tests pin both halves of the contract:
+
+  * an ACTIVE BEDROCK_MANTLE_OPENAI alias sent by the client WINS, and the outgoing
+    body carries that alias's provider_model_id (Mantle rejects our alias names);
+  * anything else (unknown alias, wrong provider, inactive, absent) silently FALLS
+    BACK to default_model — the pre-existing behaviour, which is what keeps existing
+    Codex clients (they send upstream names like "gpt-5.5-codex") working.
+
+The fallback is the regression-critical half: a strict lookup would turn every
+existing Codex request into a 404.
+
+Two exceptions to "anything else falls back", both pinned below:
+  * an INACTIVE alias is an operator kill switch → 404, never a silent substitution;
+  * a value that cannot even be used as a lookup key (non-str, lone surrogate) is
+    rejected before the resolver, because those raise DBAPIError / UnicodeEncodeError
+    rather than LookupError and would otherwise escape the fallback as a 500.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.responses import JSONResponse
+
+from app.routers.openai_compat import _handle_responses
+from app.schemas.domain import (
+    ApiFormat,
+    ModelConfigSchema,
+    ModelPricingSchema,
+    ModelStatus,
+    ProviderType,
+    TokenUsage,
+)
+from app.schemas.routing import RoutingProfileSchema
+
+ENDPOINT = "https://bedrock-mantle.us-east-2.api.aws/openai"
+
+# alias -> provider_model_id, mirroring migration 0025 + 0017.
+MANTLE_OPENAI_ALIASES = {
+    "codex-gpt": "openai.gpt-5.5",
+    "codex-gpt-5.6-sol": "openai.gpt-5.6-sol",
+    "codex-gpt-5.6-terra": "openai.gpt-5.6-terra",
+    "codex-gpt-5.6-luna": "openai.gpt-5.6-luna",
+}
+
+
+def _model_config(alias: str) -> ModelConfigSchema:
+    return ModelConfigSchema(
+        provider_model_id=MANTLE_OPENAI_ALIASES[alias],
+        alias=alias,
+        provider=ProviderType.BEDROCK_MANTLE_OPENAI,
+        api_format=ApiFormat.OPENAI_RESPONSES,
+        endpoint=ENDPOINT,
+        pricing=ModelPricingSchema(
+            input_per_1k=Decimal("0.002200"), output_per_1k=Decimal("0.013200")
+        ),
+        status=ModelStatus.ACTIVE,
+    )
+
+
+def _profile(default_model: str = "codex-gpt") -> RoutingProfileSchema:
+    # Codex = in-account (account_role_arn NULL), Ohio.
+    return RoutingProfileSchema(
+        client="codex",
+        backend="mantle",
+        account_role_arn=None,
+        region="us-east-2",
+        default_model=default_model,
+        external_id=None,
+    )
+
+
+class _FakeRequest:
+    """Minimal Request stand-in: _handle_responses reads scope["state"], app.state, body()."""
+
+    def __init__(self, body: dict, state: dict, app_state) -> None:
+        self._body = json.dumps(body).encode()
+        self.scope = {"state": state}
+        self.app = MagicMock()
+        self.app.state = app_state
+
+    async def body(self) -> bytes:
+        return self._body
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class _FakeSessionFactory:
+    """async-context-manager session factory, exercising the NON-degraded DB branch.
+
+    The default _build path leaves _session_factory None, which takes the db=None
+    branch. Selection has to behave identically when a session IS available, since
+    that is the real production path.
+    """
+
+    def __init__(self) -> None:
+        self.session = MagicMock(name="db_session")
+        self.entered = 0
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self.session
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+def _build(
+    requested_model: str | None,
+    *,
+    default_model: str = "codex-gpt",
+    include_model_key: bool = True,
+    with_session: bool = False,
+    stream: bool = False,
+    web_search: bool = False,
+):
+    """Wire up _handle_responses with fakes; returns (request, adapter, resolver_calls)."""
+    profile = _profile(default_model)
+    if web_search:
+        profile = profile.model_copy(update={"web_search_enabled": True})
+
+    # Resolver stands in for RouterService.resolve_codex_model: it knows exactly the
+    # aliases migration 0025/0017 register and raises LookupError for anything else,
+    # which is what the real resolver does for a wrong-provider/inactive/unknown ref.
+    resolver_calls: list[str] = []
+
+    async def _resolve(redis, db, model_ref):
+        resolver_calls.append(model_ref)
+        if model_ref in MANTLE_OPENAI_ALIASES:
+            return _model_config(model_ref)
+        raise LookupError(f"Model alias '{model_ref}' not found")
+
+    routing_loader = MagicMock()
+    routing_loader.load = AsyncMock(return_value=profile)
+
+    adapter = MagicMock()
+    adapter.invoke = AsyncMock(
+        return_value=(
+            200,
+            json.dumps(
+                {"status": "completed", "usage": {"input_tokens": 5, "output_tokens": 2,
+                                                 "total_tokens": 7}}
+            ).encode(),
+            {},
+            TokenUsage(input_tokens=5, output_tokens=2, total_tokens=7),
+        )
+    )
+
+    async def _chunks():
+        yield b'data: {"type":"response.completed"}\n\n'
+
+    adapter.invoke_stream = AsyncMock(
+        return_value=(200, _chunks(), {}, TokenUsage(input_tokens=5, output_tokens=2,
+                                                     total_tokens=7))
+    )
+
+    app_state = MagicMock()
+    app_state.provider_registry.get = MagicMock(return_value=adapter)
+    app_state.cost_recorder.finalize = AsyncMock()
+    app_state.routing_profile_loader = routing_loader
+    # No AgentCore MCP client → the web-search loop branch stays out of the way,
+    # unless a test explicitly opts in (web_search=True).
+    app_state.agentcore_mcp_client = MagicMock() if web_search else None
+
+    state = {
+        "auth_context": None,     # skips check_key_scope + rate limits; selection is what we test
+        "client": "codex",
+        "_redis": None,
+        # None → the is_db_degraded/no-factory branch (db=None); a factory takes the
+        # real production branch that opens a session.
+        "_session_factory": _FakeSessionFactory() if with_session else None,
+        "request_id": "req-1",
+    }
+
+    body: dict = {"input": "hello"}
+    if include_model_key:
+        body["model"] = requested_model
+    if stream:
+        body["stream"] = True
+
+    request = _FakeRequest(body, state, app_state)
+    return request, adapter, resolver_calls, _resolve
+
+
+def _sent_model(adapter) -> str:
+    """The model id actually put on the wire to Mantle."""
+    sent_body = adapter.invoke.await_args.args[0]
+    return json.loads(sent_body)["model"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alias",
+    ["codex-gpt-5.6-sol", "codex-gpt-5.6-terra", "codex-gpt-5.6-luna"],
+)
+async def test_requested_gpt56_alias_wins_over_default(monkeypatch, alias):
+    """All three GPT-5.6 aliases are reachable per request; default_model is NOT used."""
+    request, adapter, calls, resolve = _build(alias)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    # Resolved the requested alias, and never fell back to the default.
+    assert calls == [alias]
+    # Mantle gets the provider model id, not our alias.
+    assert _sent_model(adapter) == MANTLE_OPENAI_ALIASES[alias]
+    # Cost/usage is attributed to the alias actually served.
+    assert request.scope["state"]["model_config"].alias == alias
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_falls_back_to_default_no_404(monkeypatch):
+    """REGRESSION GUARD: Codex sends upstream names we do not register.
+
+    Before per-request selection these were ignored; a strict lookup would 404 every
+    existing Codex request. The fallback must keep them on default_model.
+    """
+    request, adapter, calls, resolve = _build("gpt-5.5-codex")
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200, "unknown model must NOT 404 — it falls back"
+    # Tried the requested value, then the default.
+    assert calls == ["gpt-5.5-codex", "codex-gpt"]
+    assert _sent_model(adapter) == "openai.gpt-5.5"
+
+
+@pytest.mark.asyncio
+async def test_absent_model_uses_default(monkeypatch):
+    """No "model" key at all → default_model, with no wasted resolver call."""
+    request, adapter, calls, resolve = _build(None, include_model_key=False)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert calls == ["codex-gpt"]  # empty requested alias short-circuits
+    assert _sent_model(adapter) == "openai.gpt-5.5"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_model", [123, ["codex-gpt"], {"name": "x"}, True, None])
+async def test_non_string_model_falls_back_without_500(monkeypatch, bad_model):
+    """REGRESSION GUARD: "model" is untrusted client JSON and may not be a string.
+
+    A non-text bind against the VARCHAR alias column raises DBAPIError from asyncpg —
+    NOT LookupError — so it would escape the fallback and 500. Verified against real
+    Postgres: 123 / ["a"] / {"x":1} / True all raise ProgrammingError/DBAPIError.
+    The isinstance(str) guard must keep these on default_model.
+    """
+    async def _resolve(redis, db, model_ref):
+        if not isinstance(model_ref, str):
+            raise AssertionError(f"non-str {model_ref!r} must never reach the resolver")
+        if model_ref in MANTLE_OPENAI_ALIASES:
+            return _model_config(model_ref)
+        raise LookupError(model_ref)
+
+    request, adapter, _calls, _ = _build(bad_model)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", _resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.5"  # profile default
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surrogate", ["\ud800", "codex\ud800gpt", "\udfff"])
+async def test_lone_surrogate_model_falls_back_without_500(monkeypatch, surrogate):
+    """REGRESSION GUARD: a lone UTF-16 surrogate is valid JSON and a real str.
+
+    It passes isinstance(str) and is non-empty, so a str-only guard lets it through to
+    redis.get(f"model:{ref}") -- which raises UnicodeEncodeError (redis-py encodes with
+    encoding_errors="strict"), NOT LookupError, so it escapes the fallback and 500s a
+    request that returned 200 before per-request selection existed.
+
+    The resolver here encodes the key exactly like redis-py does, so removing the
+    surrogate half of the guard makes this test fail rather than silently pass.
+    """
+    async def _resolve(redis, db, model_ref):
+        model_ref.encode("utf-8")  # what redis-py does to build the cache key
+        if model_ref in MANTLE_OPENAI_ALIASES:
+            return _model_config(model_ref)
+        raise LookupError(model_ref)
+
+    request, adapter, _calls, _ = _build(surrogate)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", _resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.5"  # profile default
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nul", ["\x00", "codex\x00gpt", "codex-gpt\x00"])
+async def test_nul_byte_model_falls_back_without_500(monkeypatch, nul):
+    """REGRESSION GUARD: a NUL byte passes isinstance AND encodes to UTF-8 cleanly.
+
+    So neither the str check nor the surrogate check catches it, but Postgres has no NUL
+    in text: asyncpg raises CharacterNotInRepertoireError (a DBAPIError, NOT LookupError).
+    Verified against real Postgres. The resolver here raises the same class the driver
+    does, so dropping the NUL guard makes this test fail.
+
+    Asserting on the RESPONSE alone would not pin the guard: the except DBAPIError
+    backstop also yields 200, so the guard could be deleted unnoticed. This asserts the
+    NUL value never reaches the resolver at all, which is the guard's actual job.
+    """
+    from sqlalchemy.exc import DBAPIError
+
+    seen: list[str] = []
+
+    async def _resolve(redis, db, model_ref):
+        seen.append(model_ref)
+        if "\x00" in model_ref:
+            # What asyncpg really raises: CharacterNotInRepertoireError, a DBAPIError.
+            raise DBAPIError("SELECT alias", {}, Exception("invalid byte sequence 0x00"))
+        if model_ref in MANTLE_OPENAI_ALIASES:
+            return _model_config(model_ref)
+        raise LookupError(model_ref)
+
+    request, adapter, _calls, _ = _build(nul)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", _resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.5"  # profile default
+    # The guard rejected it up front — the DB was never asked about a NUL-bearing value.
+    assert seen == ["codex-gpt"], f"NUL value reached the resolver: {seen!r}"
+
+
+@pytest.mark.asyncio
+async def test_overlong_model_falls_back_and_log_is_bounded(monkeypatch):
+    """An over-long value is harmless to the DB (compared by value, not column width),
+    but must NOT be logged verbatim — it is unbounded client input, so one request would
+    become a multi-MB log line.
+
+    caplog is useless here: structlog is unconfigured in tests (PrintLoggerFactory), so
+    nothing reaches stdlib logging. Capture the structlog call itself instead.
+    """
+    huge = "a" * 100_000
+    request, adapter, _calls, resolve = _build(huge)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        "app.routers.openai_compat.logger.info",
+        lambda event, **kw: logged.append({"event": event, **kw}),
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.5"
+
+    fallback = [r for r in logged
+                if r["event"] == "responses_requested_model_unresolved_using_default"]
+    assert fallback, "the silent substitution was not logged at INFO"
+    # 128 = the alias column's own width, so nothing legitimate is ever truncated.
+    assert len(fallback[0]["requested"]) <= 128, (
+        f"unbounded client value logged verbatim ({len(fallback[0]['requested'])} chars)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_null_model_falls_back(monkeypatch):
+    """{"model": null} is present-but-null — a different code path from an absent key."""
+    request, adapter, _calls, resolve = _build(None, include_model_key=True)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.5"
+
+
+@pytest.mark.asyncio
+async def test_inactive_alias_is_denied_not_substituted(monkeypatch):
+    """SECURITY/BILLING: status=INACTIVE is an operator kill switch.
+
+    A disabled alias must 404, NOT silently fall back to default_model — that would
+    both defeat the kill switch and bill the request to the wrong alias. This is why
+    the resolver raises ModelInactiveError (a LookupError subclass) for inactive and
+    the fallback re-raises it.
+    """
+    from app.services.router_service import ModelInactiveError
+
+    async def _resolve(redis, db, model_ref):
+        if model_ref == "codex-gpt-5.6-sol":
+            raise ModelInactiveError("Model 'codex-gpt-5.6-sol' is inactive")
+        return _model_config(model_ref)
+
+    request, adapter, _calls, _ = _build("codex-gpt-5.6-sol")
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", _resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 404
+    assert b"inactive" in resp.body
+    adapter.invoke.assert_not_awaited()  # never served as another model
+
+
+@pytest.mark.asyncio
+async def test_selection_works_with_db_session(monkeypatch):
+    """The production branch: a DB session is available (not degraded)."""
+    request, adapter, calls, resolve = _build("codex-gpt-5.6-sol", with_session=True)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert calls == ["codex-gpt-5.6-sol"]
+    assert _sent_model(adapter) == "openai.gpt-5.6-sol"
+    assert request.scope["state"]["_session_factory"].entered == 1
+
+
+@pytest.mark.asyncio
+async def test_selection_applies_on_stream_path(monkeypatch):
+    """stream=true takes invoke_stream; the selected model must reach it too."""
+    request, adapter, _calls, resolve = _build("codex-gpt-5.6-luna", stream=True)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    sent = json.loads(adapter.invoke_stream.await_args.args[0])
+    assert sent["model"] == "openai.gpt-5.6-luna"
+    adapter.invoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_selection_applies_on_web_search_path(monkeypatch):
+    """The web-search loop is the LIVE path wherever it is enabled (migration 0021 sets
+    web_search_enabled=true for codex), so selection must reach it as well."""
+    request, _adapter, _calls, resolve = _build("codex-gpt-5.6-terra", web_search=True)
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    captured: dict = {}
+
+    async def _capture_invoke(body, pmid, **kw):
+        captured["model"] = json.loads(body)["model"]
+        captured["pmid"] = pmid
+        return (200, b"{}", {}, TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2))
+
+    async def _fake_loop(**kwargs):
+        # Drive the router's own per-turn invoke wrapper, which is what rewrites the
+        # model for each web-search turn.
+        status, _body, _headers, _usage = await kwargs["invoke"](kwargs["initial_req_data"])
+        return JSONResponse(status_code=status, content={"ok": True})
+
+    request.app.state.provider_registry.get().invoke = AsyncMock(side_effect=_capture_invoke)
+    monkeypatch.setattr("app.services.web_search_loop.run_web_search_loop", _fake_loop)
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    # The web-search turn carried the REQUESTED model, not the profile default.
+    assert captured["model"] == "openai.gpt-5.6-terra"
+    assert captured["pmid"] == "openai.gpt-5.6-terra"
+
+
+@pytest.mark.asyncio
+async def test_requested_equals_default_resolves_once(monkeypatch):
+    """Sending the default explicitly must not resolve twice (it is the same lookup)."""
+    request, _adapter, calls, resolve = _build("codex-gpt", default_model="codex-gpt")
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert calls == ["codex-gpt"]
+
+
+@pytest.mark.asyncio
+async def test_provider_model_id_is_also_accepted(monkeypatch):
+    """The real resolver falls back to provider_model_id matching, so a client may send
+    the raw Mantle id. Selection must not block that path."""
+    async def _resolve(redis, db, model_ref):
+        if model_ref == "openai.gpt-5.6-sol":
+            return _model_config("codex-gpt-5.6-sol")
+        if model_ref in MANTLE_OPENAI_ALIASES:
+            return _model_config(model_ref)
+        raise LookupError(model_ref)
+
+    request, adapter, _calls, _ = _build("openai.gpt-5.6-sol")
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", _resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 200
+    assert _sent_model(adapter) == "openai.gpt-5.6-sol"
+
+
+@pytest.mark.asyncio
+async def test_default_model_unresolvable_still_404s(monkeypatch):
+    """A broken default (e.g. alias deleted under it) must surface as 404, not be
+    swallowed by the fallback."""
+    request, _adapter, _calls, resolve = _build(
+        None, include_model_key=False, default_model="deleted-alias"
+    )
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_scope_denial_applies_to_requested_model(monkeypatch):
+    """SECURITY: per-request selection is not an entitlement bypass.
+
+    A key scoped to codex-gpt must not reach a GPT-5.6 alias by asking for it — the
+    scope check runs on the RESOLVED model, so it denies with 400.
+    """
+    request, adapter, _calls, resolve = _build("codex-gpt-5.6-sol")
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.resolve_codex_model", resolve
+    )
+
+    auth_context = MagicMock()
+    auth_context.allowed_models = ["codex-gpt"]
+    request.scope["state"]["auth_context"] = auth_context
+
+    denied: dict = {}
+
+    def _check(ctx, model_config):
+        denied["alias"] = getattr(model_config, "alias", model_config)
+        raise PermissionError("not allowed")
+
+    monkeypatch.setattr(
+        "app.routers.openai_compat._router_service.check_key_scope", _check
+    )
+
+    resp = await _handle_responses(request)
+
+    assert resp.status_code == 400  # 400 not 403 (see test_scope_denial_400.py)
+    # The check saw the REQUESTED model, not the profile default.
+    assert denied["alias"] == "codex-gpt-5.6-sol"
+    adapter.invoke.assert_not_awaited()

--- a/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_router_service.py
+++ b/projects/awsome-ai-gateway/gateway-proxy/tests/unit/test_router_service.py
@@ -16,7 +16,7 @@ from app.schemas.domain import (
     ModelStatus,
     ProviderType,
 )
-from app.services.router_service import RouterService
+from app.services.router_service import ModelInactiveError, RouterService
 
 
 @pytest.fixture
@@ -211,6 +211,41 @@ async def test_inactive_alias_raises(sample_alias_row):
     rs = RouterService()
     with pytest.raises(LookupError, match="inactive"):
         await rs.resolve_bedrock_model(redis, db, "claude-sonnet-4-6")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resolver, model_ref",
+    [
+        ("resolve_bedrock_model", "claude-sonnet-4-6"),
+        ("resolve_codex_model", "codex-gpt"),
+    ],
+)
+async def test_inactive_raises_model_inactive_error_specifically(
+    sample_alias_row, resolver, model_ref
+):
+    """PINS THE SEAM: inactive must raise ModelInactiveError, not a bare LookupError.
+
+    routers/openai_compat._resolve_model tells the two apart on purpose: an unknown
+    alias falls back to default_model, an INACTIVE one is an operator kill switch and
+    must 404. If this collapses back to a plain LookupError, the kill switch silently
+    degrades into "serve default_model and bill the wrong alias" — and every test that
+    only asserts LookupError (the base class) would still pass. Hence this assertion on
+    the exact type, against the real resolver rather than a fake.
+    """
+    sample_alias_row.status = "INACTIVE"
+    sample_alias_row.provider = (
+        "BEDROCK" if resolver == "resolve_bedrock_model" else "BEDROCK_MANTLE_OPENAI"
+    )
+    sample_alias_row.alias = model_ref
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    db = _make_db_mock([sample_alias_row])
+
+    rs = RouterService()
+    with pytest.raises(ModelInactiveError, match="inactive"):
+        await getattr(rs, resolver)(redis, db, model_ref)
 
 
 @pytest.mark.unit

--- a/projects/awsome-ai-gateway/guides/QUICKSTART.md
+++ b/projects/awsome-ai-gateway/guides/QUICKSTART.md
@@ -73,9 +73,11 @@ claude            # 이제 그냥 실행하면 게이트웨이로 감 (Bearer VK
 ### 2-B. Codex (OpenAI Codex CLI)
 Codex 는 OpenAI **Responses API** 방언을 쓴다. `~/.codex/config.toml` 에 gateway provider 를 넣는다:
 ```toml
+model = "gpt-5.5"                      # 생략 금지 (아래 주의 참고)
 model_provider = "gateway"
 
 [model_providers.gateway]
+name = "LLM Gateway"                   # 필수 — 없으면 codex 가 config 로드를 거부
 base_url = "<ANTHROPIC_BASE_URL>/v1"   # 끝에 /v1
 wire_api = "responses"
 env_key  = "GATEWAY_VK"                # 아래 VK 를 이 env 로 참조
@@ -83,7 +85,20 @@ env_key  = "GATEWAY_VK"                # 아래 VK 를 이 env 로 참조
 ```bash
 export GATEWAY_VK="<VK>"   # gateway-cli 로 발급 (아래 부록) → codex 실행
 ```
-- 게이트웨이는 Codex 가 보내는 `originator: codex_cli_rs` 헤더로 `client=codex` 자동 식별.
+> ⚠️ **`name` 을 빠뜨리면 codex 가 아예 뜨지 않는다** (실측, Codex CLI 0.147.0):
+> `Error loading config.toml: model_providers.gateway: provider name must not be empty` 로 즉시 종료.
+> 게이트웨이 장애로 오인하기 쉬우므로 이 줄을 반드시 넣는다.
+>
+> ⚠️ **`model` 도 명시한다.** 생략하면 Codex 가 자체 기본값(0.147.0 은 `gpt-5.6-sol`)을 보내고, 이 문자열은
+> 게이트웨이 alias 와 일치하지 않는다. 현재 게이트웨이는 클라이언트가 보낸 `model` 을 무시하고 routing
+> profile 의 `default_model`(=`codex-gpt`, GPT-5.5) 로 라우팅하므로 **호출은 성공하지만**, Codex 내장
+> 메타데이터(context window 등)가 실제 모델과 어긋나 성능이 저하될 수 있다. `gpt-5.5` 를 주면 경고 없이
+> 정확한 메타데이터를 쓴다 (`gateway-clients/codex-box/entrypoint.sh:10-15` 의 실측 주석과 동일).
+
+- 게이트웨이는 Codex 가 보내는 `originator` 헤더로 `client=codex` 자동 식별.
+  값은 실행 모드에 따라 다르다 — 대화형 `codex` 는 `codex_cli_rs`, `codex exec` 는 `codex_exec`.
+  판정이 `originator.startswith("codex")` 라서 둘 다 인식된다
+  (`gateway-proxy/src/app/services/client_identifier.py:48-52`).
 - **격리 실행**(호스트 `~/.codex` 미접근): `gateway-clients/codex-box` 도커 이미지 사용 — 컨테이너 안에서만 config 생성. `gateway-clients/README.md` 참고.
 
 ### 2-C. Cowork (Claude 데스크톱 앱)

--- a/projects/awsome-ai-gateway/guides/user-guide.md
+++ b/projects/awsome-ai-gateway/guides/user-guide.md
@@ -193,6 +193,8 @@ gateway-cli setup \
   Gateway URL:     https://gateway.llm-gateway.example.com
   Admin API URL:   https://admin-api.llm-gateway.example.com
   API Key Helper:  /usr/local/bin/api-key-helper
+  OIDC Issuer:     https://login.microsoftonline.com/<TENANT>/v2.0  (from login cache)
+  OIDC Client ID:  <CLIENT_ID>
 
   Gateway enabled: /etc/claude-code/managed-settings.d/50-gateway.json
 
@@ -200,6 +202,20 @@ Restart Claude Code to apply changes.
 ```
 
 이 명령은 `/etc/claude-code/managed-settings.d/50-gateway.json`에 설정을 기록합니다. Claude Code는 이 경로를 최우선으로 읽습니다.
+
+**OIDC 값은 4단계(`gateway-cli login`)의 토큰 캐시에서 자동으로 감지됩니다.** 따로 지정하려면
+`--issuer-url` / `--client-id` 옵션이나 `OIDC_ISSUER_URL` / `OIDC_CLIENT_ID` 환경변수를 쓰세요.
+
+> **`OIDC: (not set)` 경고가 노란색으로 뜨면 반드시 해결하고 넘어가세요.** 이 두 값이 없으면
+> `api-key-helper`가 IDP 대신 **AWS STS(IAM) 모드**로 동작합니다. 결과는 두 가지인데 둘 다
+> 원인을 찾기 어렵습니다 —
+> ① AWS SSO 세션이 있으면 IDP 신원이 아니라 **IAM ARN 기준의 다른 사용자**로 VK가 발급되어
+>   Admin UI 사용자 목록에서 본인 계정을 찾을 수 없고 사용량도 엉뚱한 유저에 쌓입니다.
+> ② AWS SSO 세션이 없으면 VK를 아예 못 받아 Claude Code가 **자체 로그인 화면
+>   (`Not logged in · Please run /login`)** 으로 돌아갑니다. 게이트웨이로 붙지 않습니다.
+>
+> 해결: `gateway-cli login`을 먼저 실행한 뒤 `gateway-cli setup`을 재실행하세요.
+> 현재 상태는 `gateway-cli status`의 `Auth Mode` 줄에서 확인할 수 있습니다.
 
 ### 5.2 수동 설정 (gateway-cli setup을 사용할 수 없는 경우)
 

--- a/projects/awsome-ai-gateway/scripts/onboard-macos-linux.sh
+++ b/projects/awsome-ai-gateway/scripts/onboard-macos-linux.sh
@@ -55,7 +55,11 @@ log "로그인 완료. 토큰 캐시: ~/.gateway-cli/oidc-tokens.json"
 # ── 4. (선택) Claude Code 연동 ─────────────────────────────────
 if [ "$SETUP_CC" = "1" ]; then
   log "Claude Code 연동 (gateway-cli setup) — sudo 암호를 물을 수 있습니다"
-  gateway-cli setup --gateway-url "$ANTHROPIC_BASE_URL" --admin-api-url "$ADMIN_API_URL"
+  # --issuer-url/--client-id 를 명시한다. 없으면 managed settings 에 OIDC 키가 빠지고
+  # api-key-helper 가 STS(IAM) 모드로 떨어져, 잘못된 사용자로 VK 가 발급되거나
+  # (SSO 세션이 없으면) Claude Code 가 1P 로그인 화면으로 되돌아간다.
+  gateway-cli setup --gateway-url "$ANTHROPIC_BASE_URL" --admin-api-url "$ADMIN_API_URL" \
+    --issuer-url "$OIDC_ISSUER_URL" --client-id "$OIDC_CLIENT_ID"
   log "완료. Claude Code 재시작 후 'claude' 실행하면 게이트웨이로 갑니다. 원복: gateway-cli disable"
 else
   log "공통 1단계(로그인) 완료. Claude Code 자동연동을 원하면 --setup-claude-code 로 재실행."

--- a/projects/awsome-ai-gateway/scripts/onboard-windows.ps1
+++ b/projects/awsome-ai-gateway/scripts/onboard-windows.ps1
@@ -48,7 +48,11 @@ Log "로그인 완료. 토큰 캐시: $env:USERPROFILE\.gateway-cli\oidc-tokens.
 # 4. (선택) Claude Code 연동
 if ($SetupClaudeCode) {
   Log "Claude Code 연동 (gateway-cli setup)"
-  gateway-cli setup --gateway-url $env:ANTHROPIC_BASE_URL --admin-api-url $env:ADMIN_API_URL
+  # --issuer-url/--client-id 를 명시한다. 없으면 managed settings 에 OIDC 키가 빠지고
+  # api-key-helper 가 STS(IAM) 모드로 떨어져, 잘못된 사용자로 VK 가 발급되거나
+  # (SSO 세션이 없으면) Claude Code 가 1P 로그인 화면으로 되돌아간다.
+  gateway-cli setup --gateway-url $env:ANTHROPIC_BASE_URL --admin-api-url $env:ADMIN_API_URL `
+    --issuer-url $env:OIDC_ISSUER_URL --client-id $env:OIDC_CLIENT_ID
   Log "완료. Claude Code 재시작 후 claude 실행. 원복: gateway-cli disable"
 } else {
   Log "공통 1단계(로그인) 완료. Claude Code 자동연동은 -SetupClaudeCode 로 재실행."


### PR DESCRIPTION
Fixes defects found during a customer deployment, including one that meant model create/edit in the Admin UI **had never worked**.

## 1. Model create/edit always failed with "Validation failed" — highest user impact

`ModelCreateSchema` required `max_tokens`/`context_window`, but neither field has **a counterpart anywhere**:

| Layer | Present? |
|---|---|
| `CreateModelDialog`'s `FormState`, input, payload | ❌ no |
| backend `ModelCreateRequest` | ❌ no |
| `model.model_aliases` table | ❌ no |
| `ModelListItem` (display-only, always 0) | ✅ here only |

Because the form had no way to populate them, `safeParse` always failed with `{max_tokens: Required, context_window: Required}`. The drift dates back to the initial import and stayed hidden because every existing model was seeded by a migration. `createModelAction` and `updateModelAction` share the schema, so **both create and edit** were blocked.

→ Removed the two fields from `ModelCreateSchema` and `ModelCreateForm`.

## 2. Validation failures were invisible — what made #1 undiagnosable

Field errors are rendered only by hardcoded JSX beneath the matching `<input>`. An error on a key with no input is therefore dropped silently and the user sees a bare **"Validation failed" with no cause**. Unrenderable keys are now merged into the top-level error message so they are always shown — if the same class of drift reappears, at least the cause is visible.

## 3. Three GPT-5.6 aliases + per-request model selection (migration 0025)

Registers `codex-gpt-5.6-sol` / `-terra` / `-luna`. Previously `/v1/responses` routed only the routing profile's `default_model`, so **registering an alias left all three unreachable**.

The client-supplied `model` is now honoured only when it resolves to an ACTIVE `BEDROCK_MANTLE_OPENAI` alias; otherwise it falls back to the profile default exactly as before — Codex always sends an upstream model name rather than one of our aliases, so **existing clients are unaffected** (switching to a strict lookup would 404 every one of those requests).

This is not a permission bypass: the resolved model still has to pass `check_key_scope()`. `status=INACTIVE` is an operator kill switch, so it is rejected with 404 instead of falling back (`ModelInactiveError` — a `LookupError` subclass, so existing `except LookupError` call sites are unchanged).

## 4. Missing OIDC in `gateway-cli setup` → VK issued for the wrong user

Running setup without `--issuer-url`/`--client-id` omits the OIDC keys from managed settings and drops `api-key-helper` into AWS STS(IAM) mode. Both outcomes are hard to diagnose:

1. with an SSO session present, the VK is issued for **a different user keyed on the IAM ARN** rather than the IdP identity, so usage accrues to the wrong account
2. without one, Claude Code falls back to its **first-party login screen** instead of the gateway

→ Auto-detection from the login token cache + Auth Mode surfaced in `gateway-cli status` + the values passed explicitly from the onboarding scripts.
→ `gw.sh` now sends `id_token` instead of `access_token` (a Cognito access_token carries no email, and Entra issues `aud` for the resource → 401).

## 5. Concurrency / data integrity (migration 0024)

- `OIDCVerifier` held a `threading.Lock` across an `await`, which can **stall the event loop permanently** → `asyncio.Lock`
- overlapping deactivate-then-insert in the budget/rate-limit upsert could leave two `is_active=true` rows, after which **every lookup 500s with `MultipleResultsFound`** → advisory xact lock + partial unique index (`COALESCE` is required — NULLs are distinct in a unique index, so GLOBAL-scope / `client IS NULL` rows would otherwise go unprotected)
- `install-eks.sh`: clears the field ownership (`operation=Update`) left behind by earlier `kubectl set env` calls, which made `helm upgrade` conflict. `--force-conflicts` is deliberately not used because it applies to the whole release and would also overwrite HPA-owned `.spec.replicas`.

## i18n

The new warnings in `setup`/`status` go through the existing `_()` gettext wrapper rather than being emitted as literals, and the five new msgids are added to `locales/{en,ko}/LC_MESSAGES/gateway-cli.po`. Both catalogs compile clean under `msgfmt`, and a round-trip check through a freshly compiled `.mo` confirms all five msgids resolve under `--lang ko`. Note that no `.mo` is committed or built by the packaging today, so at runtime `gettext` falls back to `NullTranslations` and the CLI still prints English — that is the pre-existing upstream state and this PR does not change it; the catalogs are staged so the strings are ready once `.mo` compilation is wired up. The three pre-existing `_()` calls upstream are left as they are.

## 6. Ignore security-scan output artifacts

Security scanners (ASH, Holmes) write `*scan-report*.json` at the project root, and reviewer-only findings files carry date suffixes (`SECURITY-FINDINGS-<date>.md`) that the existing exact-match ignore entry does not cover. Both can embed live resource identifiers, so the entry is generalised to a glob and the scan-report pattern added.

Verified with `git check-ignore` that all five real artifact names are matched and that **no currently tracked file becomes ignored**. No Dockerfile, Helm chart, or build script references either pattern, so build contexts are unaffected.

## Verification

Run in an isolated worktree based on upstream `main` and **compared against a pristine upstream worktree by differencing the failure sets** — zero new regressions (the failing sets are identical):

| Component | baseline | this PR | failures |
|---|---|---|---|
| admin-ui new tests | — | **11/11 pass** | — |
| admin-ui `tsc --noEmit` | — | **0 errors** | — |
| admin-api | 153 pass | **191 pass** | 23 (identical) |
| gateway-proxy | 447 pass | **475 pass** | 23 (identical) |
| gateway-cli | 78 pass | **95 pass** | 28 (identical) |

- migration chain `0021→0022→0023→0024→0025` verified in sequence
- the 0024 integrity tests were run against a real PostgreSQL 16 instance rather than skipped (21 skipped → 34 passed)
- pre-existing failures (e.g. the two admin-ui KPICard cases) are in **files this PR does not touch** and reproduce identically on the upstream base (the KPICard test expects `border-yellow-500` while the component has already moved to the `border-warning` design token)

### Regression tests added

- `modelCreateSchema.test.ts` — parses an empty object to extract the schema's **effective required-key set** and fails if it goes beyond the keys the form can send. The same drift would be caught immediately.
- `CreateModelDialog.test.tsx` — asserts that an error on a key with no input still appears in the rendered text.
- `test_responses_model_selection.py` — asserts that untrusted input (non-string, lone surrogate, NUL byte) falls back to the default rather than 500ing.


---

*Supersedes #51 — same 31 files plus the `.gitignore` entry above, rebased onto current `main`.*
