### PR TITLE
fix(awsome-ai-gateway): five fresh-install fixes — tfstate us-east-1, explicit region, Helm 3/4 flag, allowedStsRegions, ALB controller ordering

### DIFF
--- a/projects/awsome-ai-gateway/deployment/scripts/bootstrap-tfstate.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/bootstrap-tfstate.sh
@@ -36,7 +36,10 @@ if aws s3api head-bucket --bucket "${TFSTATE_BUCKET}" 2>/dev/null; then
     echo "✓ S3 bucket ${TFSTATE_BUCKET} 이미 존재"
 else
     echo "==> S3 bucket 생성: ${TFSTATE_BUCKET}"
-    if [ "${AWS_REGION}" = "ap-northeast-2" ]; then
+    # LocationConstraint 를 거부하는 리전은 us-east-1 뿐이고, 나머지는 모두 요구한다.
+    # CLI 가 --region 으로부터 자동 보완하지 않는다 — 실측: ap-northeast-2 에서 생략하면
+    # IllegalLocationConstraintException, us-east-1 에서 지정하면 InvalidLocationConstraint.
+    if [ "${AWS_REGION}" = "us-east-1" ]; then
         aws s3api create-bucket --bucket "${TFSTATE_BUCKET}" --region "${AWS_REGION}"
     else
         aws s3api create-bucket \

--- a/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
@@ -383,6 +383,10 @@ helm_install() {
     SET_ARGS=(
         --set "global.imageRegistry=${ecr_registry}"
         --set "aws.region=${AWS_REGION}"
+        # SSRF 방어용 STS 허용 리전(admin-api VK 발급). 클라이언트가 GetCallerIdentity 를
+        # presign 하는 곳 = 배포 리전이므로 aws.region 과 같은 값으로 자동 주입한다.
+        # (values 기본값이 ap-northeast-2 라, 안 주입하면 다른 리전 배포에서 VK 발급 거부.)
+        --set "aws.allowedStsRegions={${AWS_REGION}}"
         --set "database.external.host=${AURORA_HOST}"
         --set "database.external.name=${AURORA_DB_NAME}"
         --set "redis.external.host=${REDIS_HOST}"

--- a/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
@@ -384,16 +384,29 @@ helm_install() {
     # SSRF 방어용 STS 허용 리전(admin-api VK 발급). 클라이언트가 GetCallerIdentity 를
     # presign 하는 곳 = 배포 리전이므로 배포 리전이 반드시 목록에 있어야 한다.
     # (values 기본값이 ap-northeast-2 라, 안 넣으면 다른 리전 배포에서 VK 발급 거부.)
-    # 단 helm 의 --set/-f 는 리스트를 병합하지 않고 통째로 치환하므로, 배포 리전만
-    # 넘기면 values 에 적어 둔 다중 리전이 조용히 잘린다 → values 의 목록을 읽어
-    # 배포 리전을 합집합으로 더한 전체 목록을 넘긴다. (블록 스타일 시퀀스 가정 —
-    # 이 repo 의 values 3종 모두 해당. 파싱 실패 시 배포 리전 단독 주입으로 폴백.)
-    STS_REGIONS_CSV=$( {
-        awk '/^[[:space:]]*allowedStsRegions:/{f=1;next}
-             f&&/^[[:space:]]*-/{sub(/^[[:space:]]*-[[:space:]]*/,"");gsub(/"/,"");print;next}
-             f{exit}' "$VALUES_FILE"
-        echo "$AWS_REGION"
-    } | awk 'NF && !seen[$0]++' | paste -sd, -)
+    #
+    # 단 helm 의 --set/-f 는 리스트를 병합하지 않고 통째로 치환한다. 배포 리전만
+    # 넘기면 values 에 적어 둔 다중 리전이 조용히 잘리므로(= SSRF allowlist 축소),
+    # 지금 values 로 렌더되는 값을 그대로 읽어 배포 리전을 합집합으로 더한다.
+    # 읽기는 helm 에게 맡긴다 — YAML 을 직접 파싱하면 인라인 주석·flow 스타일
+    # (["a","b"])·차트 기본값 상속에서 조용히 틀린 목록이 나온다(실제로 겪음).
+    local rendered
+    if ! rendered=$(helm template "$RELEASE_NAME" "$CHART_DIR" -f "$VALUES_FILE" 2>&1); then
+        err "helm template 실패 — values 를 렌더할 수 없어 STS 허용 리전을 확정할 수 없음:"
+        printf '%s\n' "$rendered" | tail -5 >&2
+        exit 1
+    fi
+    # 아래 두 곳은 파이프 대신 herestring 을 쓴다 — `printf | grep -q`/`| awk …exit` 는
+    # 소비자가 먼저 닫아 printf 가 SIGPIPE 로 죽고, set -o pipefail 때문에 "못 찾음"
+    # 으로 잘못 판정된다(입력 크기에 따라 간헐적으로 재현).
+    if [[ "$rendered" != *"name: ALLOWED_STS_REGIONS"* ]]; then
+        err "렌더 결과에 ALLOWED_STS_REGIONS 가 없음 — 차트와 스크립트가 어긋났는지 확인 필요"
+        exit 1
+    fi
+    local sts_current
+    sts_current=$(awk '/name: ALLOWED_STS_REGIONS/{getline; sub(/.*value: */,""); gsub(/"/,""); print; exit}' <<<"$rendered")
+    STS_REGIONS_CSV=$(printf '%s\n%s\n' "${sts_current//,/$'\n'}" "$AWS_REGION" |
+        awk 'NF && !seen[$0]++' | paste -sd, -)
 
     # --set 명령 조립
     SET_ARGS=(

--- a/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
@@ -19,6 +19,18 @@
 
 set -euo pipefail
 
+# ---- 리전 확정 ----
+# 이 스크립트의 aws 호출(secretsmanager describe-secret 등)은 --region 을 명시하지 않아
+# 셸 기본 리전을 따른다. 리전이 안 잡힌 셸에서 실행하면 Secrets Manager preflight 가
+# 엉뚱한 리전을 뒤져 "Secret 없음" 으로 오판하므로, 추측하지 말고 즉시 중단한다.
+# 우선순위: AWS_REGION > AWS_DEFAULT_REGION. 그 뒤 둘을 통일.
+: "${AWS_REGION:=${AWS_DEFAULT_REGION:-}}"
+if [ -z "$AWS_REGION" ]; then
+    echo "ERROR: region is not set. export AWS_DEFAULT_REGION=<region> (e.g. ap-northeast-2) and retry." >&2
+    exit 1
+fi
+export AWS_REGION AWS_DEFAULT_REGION="$AWS_REGION"
+
 # ---- 인자 ----
 ENV="${1:-}"
 if [ -z "$ENV" ] || { [ "$ENV" != "dev" ] && [ "$ENV" != "prod" ]; }; then
@@ -406,7 +418,15 @@ helm_install() {
     # helm upgrade --install 로 통합: release 없으면 install, 있으면 upgrade.
     # `--cleanup-on-fail` 은 upgrade 경로에서만 유효한 플래그라서, install 모드에서
     # 별도 helm install 명령을 쓰면 에러. upgrade --install 로 통일하면 항상 OK.
-    # `--atomic` 은 helm v4 에서 deprecated → `--rollback-on-failure` 사용.
+    # rollback 플래그는 Helm 메이저 버전에 따라 다름:
+    #   v3 = --atomic (--rollback-on-failure 는 unknown flag), v4 = --rollback-on-failure.
+    # 사전 요구사항이 Helm >=3.14 이므로 런타임에 감지해 맞는 플래그를 쓴다.
+    HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')
+    if [ "${HELM_MAJOR:-3}" -ge 4 ]; then
+        ROLLBACK_FLAG="--rollback-on-failure"
+    else
+        ROLLBACK_FLAG="--atomic"
+    fi
     #
     # DEBUG_MODE=true 로 실행하면 실패 시 rollback/cleanup 을 하지 않아 실패한 Pod 와
     # Deployment 가 그대로 남음 → `kubectl logs <pod> --previous` 로 crash 원인 조사 가능.
@@ -426,7 +446,7 @@ helm_install() {
                 --values "$VALUES_FILE" \
                 "${SET_ARGS[@]}" \
                 --force-conflicts \
-                --rollback-on-failure \
+                "$ROLLBACK_FLAG" \
                 --cleanup-on-fail \
                 --timeout 15m \
                 --wait
@@ -435,7 +455,7 @@ helm_install() {
                 --namespace "$NAMESPACE" \
                 --values "$VALUES_FILE" \
                 "${SET_ARGS[@]}" \
-                --rollback-on-failure \
+                "$ROLLBACK_FLAG" \
                 --cleanup-on-fail \
                 --timeout 15m \
                 --wait

--- a/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
+++ b/projects/awsome-ai-gateway/deployment/scripts/install-eks.sh
@@ -23,8 +23,10 @@ set -euo pipefail
 # 이 스크립트의 aws 호출(secretsmanager describe-secret 등)은 --region 을 명시하지 않아
 # 셸 기본 리전을 따른다. 리전이 안 잡힌 셸에서 실행하면 Secrets Manager preflight 가
 # 엉뚱한 리전을 뒤져 "Secret 없음" 으로 오판하므로, 추측하지 말고 즉시 중단한다.
-# 우선순위: AWS_REGION > AWS_DEFAULT_REGION. 그 뒤 둘을 통일.
-: "${AWS_REGION:=${AWS_DEFAULT_REGION:-}}"
+# 우선순위: AWS_REGION > AWS_DEFAULT_REGION > ~/.aws/config (aws configure get region).
+# 그 뒤 둘을 통일. config 폴백이 없으면 env 없이 ~/.aws/config 로만 리전을 잡은 셸에서
+# aws CLI 자체는 정상 동작하는데도 이 가드가 거부하는 오탐이 난다.
+: "${AWS_REGION:=${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}"
 if [ -z "$AWS_REGION" ]; then
     echo "ERROR: region is not set. export AWS_DEFAULT_REGION=<region> (e.g. ap-northeast-2) and retry." >&2
     exit 1
@@ -379,14 +381,25 @@ helm_install() {
     aws_account_id=$(aws sts get-caller-identity --query Account --output text)
     local ecr_registry="${aws_account_id}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
+    # SSRF 방어용 STS 허용 리전(admin-api VK 발급). 클라이언트가 GetCallerIdentity 를
+    # presign 하는 곳 = 배포 리전이므로 배포 리전이 반드시 목록에 있어야 한다.
+    # (values 기본값이 ap-northeast-2 라, 안 넣으면 다른 리전 배포에서 VK 발급 거부.)
+    # 단 helm 의 --set/-f 는 리스트를 병합하지 않고 통째로 치환하므로, 배포 리전만
+    # 넘기면 values 에 적어 둔 다중 리전이 조용히 잘린다 → values 의 목록을 읽어
+    # 배포 리전을 합집합으로 더한 전체 목록을 넘긴다. (블록 스타일 시퀀스 가정 —
+    # 이 repo 의 values 3종 모두 해당. 파싱 실패 시 배포 리전 단독 주입으로 폴백.)
+    STS_REGIONS_CSV=$( {
+        awk '/^[[:space:]]*allowedStsRegions:/{f=1;next}
+             f&&/^[[:space:]]*-/{sub(/^[[:space:]]*-[[:space:]]*/,"");gsub(/"/,"");print;next}
+             f{exit}' "$VALUES_FILE"
+        echo "$AWS_REGION"
+    } | awk 'NF && !seen[$0]++' | paste -sd, -)
+
     # --set 명령 조립
     SET_ARGS=(
         --set "global.imageRegistry=${ecr_registry}"
         --set "aws.region=${AWS_REGION}"
-        # SSRF 방어용 STS 허용 리전(admin-api VK 발급). 클라이언트가 GetCallerIdentity 를
-        # presign 하는 곳 = 배포 리전이므로 aws.region 과 같은 값으로 자동 주입한다.
-        # (values 기본값이 ap-northeast-2 라, 안 주입하면 다른 리전 배포에서 VK 발급 거부.)
-        --set "aws.allowedStsRegions={${AWS_REGION}}"
+        --set "aws.allowedStsRegions={${STS_REGIONS_CSV}}"
         --set "database.external.host=${AURORA_HOST}"
         --set "database.external.name=${AURORA_DB_NAME}"
         --set "redis.external.host=${REDIS_HOST}"
@@ -422,9 +435,9 @@ helm_install() {
     # helm upgrade --install 로 통합: release 없으면 install, 있으면 upgrade.
     # `--cleanup-on-fail` 은 upgrade 경로에서만 유효한 플래그라서, install 모드에서
     # 별도 helm install 명령을 쓰면 에러. upgrade --install 로 통일하면 항상 OK.
-    # rollback 플래그는 Helm 메이저 버전에 따라 다름:
-    #   v3 = --atomic (--rollback-on-failure 는 unknown flag), v4 = --rollback-on-failure.
-    # 사전 요구사항이 Helm >=3.14 이므로 런타임에 감지해 맞는 플래그를 쓴다.
+    # rollback 플래그 분기는 v3 때문에 필요하다: v3 에는 --rollback-on-failure 가 아예
+    # 없어 unknown flag 로 죽는다. 반대로 v4 의 --atomic 은 deprecation warning 일 뿐
+    # 여전히 동작한다. 사전 요구사항이 Helm >=3.14 이므로 런타임에 감지해 골라 쓴다.
     HELM_MAJOR=$(helm version --template '{{.Version}}' 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')
     if [ "${HELM_MAJOR:-3}" -ge 4 ]; then
         ROLLBACK_FLAG="--rollback-on-failure"

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
@@ -79,6 +79,17 @@ module "alb_controller" {
   aws_region        = var.aws_region
 
   tags = var.tags
+
+  # Fargate 프로파일이 ACTIVE 된 뒤에 helm_release 를 시작해야 한다.
+  # 위 인자(cluster_name/oidc_provider_arn/vpc_id)는 클러스터 생성 직후 확정되므로
+  # 이것만으로는 fargate_profiles·cluster_addons 에 대한 의존이 그래프에 안 잡히고,
+  # terraform 이 프로파일 생성과 helm_release 를 병렬로 돌린다.
+  # Fargate 는 Pod 를 만들 때 매칭되는 프로파일이 있어야 fargate-scheduler 에
+  # 배정한다. 프로파일보다 먼저 생긴 Pod 는 기본 스케줄러에 배정되어, 노드가 없는
+  # Fargate 전용 클러스터에서 영원히 Pending 으로 남는다(나중에 프로파일이 ACTIVE
+  # 돼도 구제되지 않음) → helm timeout(900s) → atomic 으로 uninstall → apply 실패.
+  # 재실행하면 프로파일이 이미 ACTIVE 라 통과하는 것이 이 문제의 증상이다.
+  depends_on = [module.eks]
 }
 
 module "external_secrets" {

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
@@ -73,6 +73,17 @@ module "alb_controller" {
   aws_region        = var.aws_region
 
   tags = var.tags
+
+  # Fargate 프로파일이 ACTIVE 된 뒤에 helm_release 를 시작해야 한다.
+  # 위 인자(cluster_name/oidc_provider_arn/vpc_id)는 클러스터 생성 직후 확정되므로
+  # 이것만으로는 fargate_profiles·cluster_addons 에 대한 의존이 그래프에 안 잡히고,
+  # terraform 이 프로파일 생성과 helm_release 를 병렬로 돌린다.
+  # Fargate 는 Pod 를 만들 때 매칭되는 프로파일이 있어야 fargate-scheduler 에
+  # 배정한다. 프로파일보다 먼저 생긴 Pod 는 기본 스케줄러에 배정되어, 노드가 없는
+  # Fargate 전용 클러스터에서 영원히 Pending 으로 남는다(나중에 프로파일이 ACTIVE
+  # 돼도 구제되지 않음) → helm timeout(900s) → atomic 으로 uninstall → apply 실패.
+  # 재실행하면 프로파일이 이미 ACTIVE 라 통과하는 것이 이 문제의 증상이다.
+  depends_on = [module.eks]
 }
 
 module "external_secrets" {


### PR DESCRIPTION
## Summary

Five small fixes (four commits) for problems that break a **fresh install** in specific regions or environments. All were found by standing up new deployments (us-west-2, and a second AWS account) from an unmodified checkout, and have been running in production on our deployments since.

## Fixes

### 1. `bootstrap-tfstate.sh` — bucket creation fails in us-east-1

`s3api create-bucket` must omit `LocationConstraint` **only in us-east-1**, but the special case was keyed on `ap-northeast-2`. Choosing us-east-1 stops the very first infra step with `InvalidLocationConstraint`. Measured with the AWS CLI: us-east-1 + constraint → `InvalidLocationConstraint`; ap-northeast-2 without constraint → `IllegalLocationConstraintException`. Keying the branch on us-east-1 fixes both paths; the script was run end-to-end in both regions (S3 + DynamoDB created, test resources removed).

### 2. `install-eks.sh` — require an explicit region

Region-agnostic `aws` calls in the script (e.g. the Secrets Manager preflight) could resolve to a different region than the deployment, producing a false "secret missing" (observed 2026-07-04). `AWS_REGION`/`AWS_DEFAULT_REGION` are now unified and exported, and the script fails fast if neither is set instead of guessing.

### 3. `install-eks.sh` — Helm 3/4 rollback flag detection

Helm 3 has no `--rollback-on-failure` and dies with `unknown flag`; Helm 4 still accepts `--atomic` but only as a deprecation warning. Detect the major version at runtime and pick the flag that exists. Confirmed on a live deploy host running Helm v3.21.3, where `helm upgrade --help` lists `--atomic` and no `--rollback-on-failure`.

### 4. `install-eks.sh` — make sure the deployment region is in `aws.allowedStsRegions`

values ships `aws.allowedStsRegions: ["ap-northeast-2"]`, which admin-api uses to allow-list STS hosts during virtual-key issuance (SSRF guard). Clients presign in the deployment region, so on a non-Seoul deployment the Seoul default rejects VK issuance via the STS path. `aws.region` is already auto-injected from the deployment region; make this list follow it too.

Helm merges neither `--set` nor `-f` for lists — either one replaces the whole sequence — so injecting just the deployment region would silently shrink a values file that lists more than one region. The script therefore reads the list out of the values file and passes the **union** of that list and the deployment region (duplicates dropped, order kept). If the list can't be parsed (flow style, empty, key absent) it falls back to the deployment region alone, which is the behaviour this PR started with.

Note the consequence on a stock values file: the shipped `ap-northeast-2` is preserved alongside the deployment region. That is the price of never narrowing an operator's list; if you would rather a stock install end up with exactly one region, emptying the chart default is the cleaner change (`_split_csv` in `admin-api/src/app/core/config.py` already maps an empty value to `[]`).

### 5. terraform — ALB controller must wait for the EKS module

`module "alb_controller"`'s inputs resolve as soon as the cluster and OIDC provider exist, none of which imply the Fargate profiles are ACTIVE — so Terraform may start the helm_release while profiles are still creating. On a Fargate-only cluster, a pod created before a matching profile exists is never rescheduled onto Fargate; it stays Pending until helm's 900s timeout tears the release down and the apply fails. A re-run succeeds (profiles are ACTIVE by then), which makes the race look like flakiness. Depend on the EKS module as a whole, matching what `module "external_secrets"` already does one block below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5MXBACHT96TGZncoAbFeW

