### PR TITLE
feat(awsome-ai-gateway): make IRSA mantle_regions configurable via tfvars

### DIFF
--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/main.tf
@@ -61,6 +61,7 @@ module "irsa" {
   oidc_provider_arn          = module.eks.oidc_provider_arn
   k8s_namespace              = var.application_namespace
   bedrock_allowed_model_arns = var.bedrock_allowed_model_arns
+  mantle_regions             = var.mantle_regions
   cognito_user_pool_arn      = module.cognito.user_pool_arn
   cowork_role_arn            = var.cowork_role_arn
   claude_code_374_role_arn   = var.claude_code_374_role_arn

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/variables.tf
@@ -137,6 +137,13 @@ variable "bedrock_allowed_model_arns" {
   ]
 }
 
+variable "mantle_regions" {
+  # gateway-proxy IRSA 가 in-account Bedrock Mantle 을 호출할 수 있는 리전.
+  # 기본 = Tokyo(Claude Code/Cowork) + Ohio(Codex). US 단일계정 배포는 ["us-east-1"].
+  type    = list(string)
+  default = ["ap-northeast-1", "us-east-2"]
+}
+
 variable "eks_access_entries" {
   type    = any
   default = {}

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-dev/variables.tf
@@ -140,8 +140,9 @@ variable "bedrock_allowed_model_arns" {
 variable "mantle_regions" {
   # gateway-proxy IRSA 가 in-account Bedrock Mantle 을 호출할 수 있는 리전.
   # 기본 = Tokyo(Claude Code/Cowork) + Ohio(Codex). US 단일계정 배포는 ["us-east-1"].
-  type    = list(string)
-  default = ["ap-northeast-1", "us-east-2"]
+  type     = list(string)
+  nullable = false
+  default  = ["ap-northeast-1", "us-east-2"]
 }
 
 variable "eks_access_entries" {

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/main.tf
@@ -57,6 +57,7 @@ module "irsa" {
   oidc_provider_arn          = module.eks.oidc_provider_arn
   k8s_namespace              = var.application_namespace
   bedrock_allowed_model_arns = var.bedrock_allowed_model_arns
+  mantle_regions             = var.mantle_regions
   cognito_user_pool_arn      = module.cognito.user_pool_arn
 
   tags = var.tags

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/variables.tf
@@ -147,6 +147,13 @@ variable "bedrock_allowed_model_arns" {
   ]
 }
 
+variable "mantle_regions" {
+  # gateway-proxy IRSA 가 in-account Bedrock Mantle 을 호출할 수 있는 리전.
+  # 기본 = Tokyo(Claude Code/Cowork) + Ohio(Codex). US 단일계정 배포는 ["us-east-1"].
+  type    = list(string)
+  default = ["ap-northeast-1", "us-east-2"]
+}
+
 variable "eks_access_entries" {
   type    = any
   default = {}

--- a/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/environments/llm-gateway-prod/variables.tf
@@ -150,8 +150,9 @@ variable "bedrock_allowed_model_arns" {
 variable "mantle_regions" {
   # gateway-proxy IRSA 가 in-account Bedrock Mantle 을 호출할 수 있는 리전.
   # 기본 = Tokyo(Claude Code/Cowork) + Ohio(Codex). US 단일계정 배포는 ["us-east-1"].
-  type    = list(string)
-  default = ["ap-northeast-1", "us-east-2"]
+  type     = list(string)
+  nullable = false
+  default  = ["ap-northeast-1", "us-east-2"]
 }
 
 variable "eks_access_entries" {

--- a/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/main.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/main.tf
@@ -13,12 +13,12 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  # Bedrock Mantle 서비스 엔드포인트 리전들 (일반 Bedrock 서울과 구별되는 별도 네임스페이스).
-  #   - ap-northeast-1 (Tokyo): Claude Code in-account Mantle(claude-opus-4-8-mantle).
-  #   - us-east-2 (Ohio): Codex in-account Mantle GPT-5.5 (openai.gpt-5.5, Responses API).
-  #     Codex 호출 계정 == gateway-proxy IRSA 계정(859)이라 cross-account assume 불필요 —
-  #     이 in-account 권한만으로 충분(라이브 probe 로 us-east-2 GPT-5.5 200 OK 확인).
-  mantle_regions = ["ap-northeast-1", "us-east-2"]
+  # gateway-proxy IRSA 가 in-account Bedrock Mantle(bedrock-mantle:*) 를 호출할 수 있는 리전.
+  # 배포별로 다르므로 var.mantle_regions 로 주입 (기본값 = Tokyo + Ohio, variables.tf 참조):
+  #   - ap-northeast-1 (Tokyo): Claude Code / Cowork in-account Mantle.
+  #   - us-east-2 (Ohio): Codex in-account Mantle GPT-5.5 (Responses API).
+  #   - 다른 리전 배포는 tfvars 에서 mantle_regions = ["us-east-1"] 처럼 지정.
+  mantle_regions = var.mantle_regions
 }
 
 # ------------------------------------------------------------------------------

--- a/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/variables.tf
@@ -29,6 +29,12 @@ variable "bedrock_allowed_model_arns" {
   # ]
 }
 
+variable "mantle_regions" {
+  description = "gateway-proxy IRSA 가 in-account Bedrock Mantle(bedrock-mantle:CreateInference/GetInference) 를 호출할 수 있는 리전 목록. 배포 리전에 맞춰 tfvars 에서 지정 (예: US 단일계정 = [\"us-east-1\"])."
+  type        = list(string)
+  default     = ["ap-northeast-1", "us-east-2"]
+}
+
 variable "secrets_manager_kms_key_arns" {
   description = "Secrets Manager가 쓰는 KMS 키 ARN (기본 AWS 관리 키 + 사용자 키)"
   type        = list(string)

--- a/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/variables.tf
+++ b/projects/awsome-ai-gateway/deployment/terraform/modules/irsa/variables.tf
@@ -32,7 +32,10 @@ variable "bedrock_allowed_model_arns" {
 variable "mantle_regions" {
   description = "gateway-proxy IRSA 가 in-account Bedrock Mantle(bedrock-mantle:CreateInference/GetInference) 를 호출할 수 있는 리전 목록. 배포 리전에 맞춰 tfvars 에서 지정 (예: US 단일계정 = [\"us-east-1\"])."
   type        = list(string)
-  default     = ["ap-northeast-1", "us-east-2"]
+  # default 는 변수를 생략했을 때만 쓰인다. nullable 이 없으면 명시적 null 이 그대로
+  # 전파돼 main.tf 의 for 표현식이 "Iteration over null value" 로 죽는다.
+  nullable = false
+  default  = ["ap-northeast-1", "us-east-2"]
 }
 
 variable "secrets_manager_kms_key_arns" {


### PR DESCRIPTION
## Summary

The gateway-proxy IRSA policy scopes in-account Bedrock Mantle actions (`bedrock-mantle:CreateInference`/`GetInference`) to a hardcoded local `["ap-northeast-1", "us-east-2"]`, so any deployment using Mantle in another region has to edit the module source.

Promote the list to a `mantle_regions` variable, wired through `modules/irsa` and both `llm-gateway-{dev,prod}` environments. The default is unchanged (Tokyo + Ohio), so existing deployments are unaffected; other deployments set it in tfvars:

```hcl
mantle_regions = ["us-east-1"]
```

`terraform validate` passes for both environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5MXBACHT96TGZncoAbFeW
